### PR TITLE
Perform minor code cleanup.

### DIFF
--- a/week0/frozenlake.ipynb
+++ b/week0/frozenlake.ipynb
@@ -73,11 +73,11 @@
    },
    "outputs": [],
    "source": [
-    "print(\"initial observation code:\",env.reset())\n",
+    "print(\"initial observation code:\", env.reset())\n",
     "print('printing observation:')\n",
     "env.render()\n",
-    "print(\"observations:\",env.observation_space, 'n=',env.observation_space.n)\n",
-    "print(\"actions:\",env.action_space, 'n=',env.action_space.n)"
+    "print(\"observations:\", env.observation_space, 'n=', env.observation_space.n)\n",
+    "print(\"actions:\", env.action_space, 'n=', env.action_space.n)"
    ]
   },
   {
@@ -90,9 +90,9 @@
    "source": [
     "print(\"taking action 2 (right)\")\n",
     "new_obs, reward, is_done, _ = env.step(2)\n",
-    "print(\"new observation code:\",new_obs)\n",
+    "print(\"new observation code:\", new_obs)\n",
     "print(\"reward:\", reward)\n",
-    "print(\"is game over?:\",is_done)\n",
+    "print(\"is game over?:\", is_done)\n",
     "print(\"printing new state:\")\n",
     "env.render()"
    ]
@@ -184,10 +184,10 @@
     "assert all([len(p) == n_states for p in policies]), 'policy length should always be 16'\n",
     "assert np.min(policies) == 0, 'minimal action id should be 0'\n",
     "assert np.max(policies) == n_actions-1, 'maximal action id should match n_actions-1'\n",
-    "action_probas = np.unique(policies,return_counts=True)[-1] /10**4. /n_states\n",
-    "print (\"Action frequencies over 10^4 samples:\",action_probas)\n",
-    "assert np.allclose(action_probas,[1./n_actions]*n_actions,atol=0.05), \"The policies aren't uniformly random (maybe it's just an extremely bad luck)\"\n",
-    "print (\"Seems fine!\")"
+    "action_probas = np.unique(policies, return_counts=True)[-1] /10**4. /n_states\n",
+    "print(\"Action frequencies over 10^4 samples:\",action_probas)\n",
+    "assert np.allclose(action_probas, [1. / n_actions] * n_actions, atol=0.05), \"The policies aren't uniformly random (maybe it's just an extremely bad luck)\"\n",
+    "print(\"Seems fine!\")"
    ]
   },
   {
@@ -206,7 +206,7 @@
    },
    "outputs": [],
    "source": [
-    "def sample_reward(env,policy,t_max=100):\n",
+    "def sample_reward(env, policy, t_max=100):\n",
     "    \"\"\"\n",
     "    Interact with an environment, return sum of all rewards.\n",
     "    If game doesn't end on t_max (e.g. agent walks into a wall), \n",
@@ -228,11 +228,11 @@
    },
    "outputs": [],
    "source": [
-    "print (\"generating 10^3 sessions...\")\n",
+    "print(\"generating 10^3 sessions...\")\n",
     "rewards = [sample_reward(env,get_random_policy()) for _ in range(10**3)]\n",
-    "assert all([type(r) in (int,float) for r in rewards]), 'sample_reward must return a single number'\n",
+    "assert all([type(r) in (int, float) for r in rewards]), 'sample_reward must return a single number'\n",
     "assert all([0 <= r <= 1 for r in rewards]), 'total rewards should be between 0 and 1 for frozenlake (if solving taxi, delete this line)'\n",
-    "print (\"Looks good!\")"
+    "print(\"Looks good!\")"
    ]
   },
   {
@@ -243,7 +243,7 @@
    },
    "outputs": [],
    "source": [
-    "def evaluate(policy,n_times=100):\n",
+    "def evaluate(policy, n_times=100):\n",
     "    \"\"\"Run several evaluations and average the score the policy gets.\"\"\"\n",
     "    rewards = <your code>\n",
     "    return float(np.mean(rewards))\n",
@@ -261,17 +261,17 @@
     "def print_policy(policy):\n",
     "    \"\"\"a function that displays a policy in a human-readable way.\"\"\"\n",
     "    lake = \"SFFFFHFHFFFHHFFG\"\n",
-    "    assert env.spec.id == \"FrozenLake-v0\",\"this function only works with frozenlake 4x4\"\n",
+    "    assert env.spec.id == \"FrozenLake-v0\", \"this function only works with frozenlake 4x4\"\n",
     "\n",
     "    \n",
     "    # where to move from each tile\n",
     "    arrows = ['<v>^'[a] for a in policy]\n",
     "    \n",
     "    #draw arrows above S and F only\n",
-    "    signs = [arrow if tile in \"SF\" else tile for arrow,tile in zip(arrows,lake)]\n",
+    "    signs = [arrow if tile in \"SF\" else tile for arrow, tile in zip(arrows, lake)]\n",
     "    \n",
-    "    for i in range(0,16,4):\n",
-    "        print ' '.join(signs[i:i+4])\n",
+    "    for i in range(0, 16, 4):\n",
+    "        print(' '.join(signs[i:i+4]))\n",
     "\n",
     "print(\"random policy:\")\n",
     "print_policy(get_random_policy())"
@@ -302,8 +302,8 @@
     "    if score > best_score:\n",
     "        best_score = score\n",
     "        best_policy = policy\n",
-    "        print (\"New best score:\",score)\n",
-    "        print \"Best policy:\"\n",
+    "        print(\"New best score:\", score)\n",
+    "        print(\"Best policy:\")\n",
     "        print_policy(best_policy)"
    ]
   },
@@ -326,7 +326,7 @@
    },
    "outputs": [],
    "source": [
-    "def crossover(policy1,policy2,p=0.5):\n",
+    "def crossover(policy1, policy2, p=0.5):\n",
     "    \"\"\"\n",
     "    for each state, with probability p take action from policy1, else policy2\n",
     "    \"\"\"\n",
@@ -342,7 +342,7 @@
    },
    "outputs": [],
    "source": [
-    "def mutation(policy,p=0.1):\n",
+    "def mutation(policy, p=0.1):\n",
     "    \"\"\"\n",
     "    for each state, with probability p replace action with random action\n",
     "    Tip: mutation can be written as crossover with random policy\n",
@@ -361,15 +361,15 @@
    "outputs": [],
    "source": [
     "np.random.seed(1234)\n",
-    "policies = [crossover(get_random_policy(),get_random_policy()) \n",
+    "policies = [crossover(get_random_policy(), get_random_policy()) \n",
     "            for i in range(10**4)]\n",
     "\n",
     "assert all([len(p) == n_states for p in policies]), 'policy length should always be 16'\n",
     "assert np.min(policies) == 0, 'minimal action id should be 0'\n",
     "assert np.max(policies) == n_actions-1, 'maximal action id should be n_actions-1'\n",
     "\n",
-    "assert any([np.mean(crossover(np.zeros(n_states),np.ones(n_states))) not in (0,1)\n",
-    "               for _ in range(100)]),\"Make sure your crossover changes each action independently\"\n",
+    "assert any([np.mean(crossover(np.zeros(n_states), np.ones(n_states))) not in (0, 1)\n",
+    "               for _ in range(100)]), \"Make sure your crossover changes each action independently\"\n",
     "print(\"Seems fine!\")"
    ]
   },
@@ -396,7 +396,7 @@
    },
    "outputs": [],
    "source": [
-    "print \"initializing...\"\n",
+    "print(\"initializing...\")\n",
     "pool = <spawn a list of pool_size random policies>\n",
     "pool_scores = <evaluate every policy in the pool, return list of scores>\n"
    ]
@@ -411,7 +411,7 @@
    "source": [
     "assert type(pool) == type(pool_scores) == list\n",
     "assert len(pool) == len(pool_scores) == pool_size\n",
-    "assert all([type(score) in (float,int) for score in pool_scores])\n"
+    "assert all([type(score) in (float, int) for score in pool_scores])\n"
    ]
   },
   {
@@ -424,7 +424,7 @@
    "source": [
     "#main loop\n",
     "for epoch in range(n_epochs):\n",
-    "    print (\"Epoch %s:\"%epoch)\n",
+    "    print(\"Epoch %s:\"%epoch)\n",
     "    \n",
     "    crossovered = <crossover random guys from pool, n_crossovers total>\n",
     "    mutated = <add several new policies at random, n_mutations total>\n",
@@ -441,7 +441,7 @@
     "    pool_scores = [pool_scores[i] for i in selected_indices]\n",
     "\n",
     "    #print the best policy so far (last in ascending score order)\n",
-    "    print (\"best score:\",pool_scores[-1])\n",
+    "    print(\"best score:\", pool_scores[-1])\n",
     "    print_policy(pool[-1])"
    ]
   },
@@ -504,21 +504,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Make code more PEP8-compliant through adding missing spaces after semicolons.
  E.g. "def foo(a,b): ..." -> "foo(a, b): ...".
* Complete Python 2 <-> Python 3 compatibility transition by adding
  missing parenthesis in several "print" function calls.