### PR TITLE
fix/rename get_new_vpi  to porper name in tests

### DIFF
--- a/week2_value_based/seminar1_VI.ipynb
+++ b/week2_value_based/seminar1_VI.ipynb
@@ -737,8 +737,7 @@
    "source": [
     "def compute_vpi(mdp, policy, gamma):\n",
     "    \"\"\"\n",
-    "    Computes updated V^pi(s) FOR ALL STATES under given policy.\n",
-    "    :param state_values: a dict of previous state values {state : V(s)}\n",
+    "    Computes V^pi(s) FOR ALL STATES under given policy.\n",
     "    :param policy: a dict of currently chosen actions {s : a}\n",
     "    :returns: a dict {state : V^pi(state) for all states}\n",
     "    \"\"\"\n",
@@ -755,7 +754,7 @@
    "outputs": [],
    "source": [
     "test_policy = {s: np.random.choice(mdp.get_possible_actions(s)) for s in mdp.get_all_states()}\n",
-    "new_vpi = get_new_vpi(mdp, test_policy, gamma)\n",
+    "new_vpi = compute_vpi(mdp, test_policy, gamma)\n",
     "\n",
     "print(new_vpi)\n",
     "\n",


### PR DESCRIPTION
- `get_new_vpi` renamed to `compute_vpi` in test
- removed `:param state_values:` from docstring for `compute_vpi` function.