### PR TITLE
Fix:  memory bloating when training

### DIFF
--- a/week4_approx_rl/homework_tf.ipynb
+++ b/week4_approx_rl/homework_tf.ipynb
@@ -467,7 +467,8 @@
     "    assigns = []\n",
     "    for w_agent, w_target in zip(agent.weights, target_network.weights):\n",
     "        assigns.append(tf.assign(w_target, w_agent, validate_shape=True))\n",
-    "    tf.get_default_session().run(assigns)"
+    "    # tf.get_default_session().run(assigns)\n",
+    "    return assigns"
    ]
   },
   {
@@ -478,8 +479,9 @@
    },
    "outputs": [],
    "source": [
-    "load_weigths_into_target_network(agent, target_network) \n",
-    "\n",
+    "# create the tf copy graph only once.\n",
+    "copy_step=load_weigths_into_target_network(agent, target_network) \n",
+    "sess.run(copy_step)\n",
     "# check that it works\n",
     "sess.run([tf.assert_equal(w, w_target) for w, w_target in zip(agent.weights, target_network.weights)]);\n",
     "print(\"It works!\")"
@@ -665,7 +667,11 @@
     "    \n",
     "    # adjust agent parameters\n",
     "    if i % 500 == 0:\n",
-    "        load_weigths_into_target_network(agent, target_network)\n",
+    "        #load_weigths_into_target_network(agent, target_network)\n",
+    "        #calling 'load_weights_into_target_network' repeatedly cause creating tf copy operator\n",
+    "        #again and again, which bloat memory consumption along training step\n",
+    "        #create'copy_step' once \n",
+    "        sess.run(copy_step)\n",
     "        agent.epsilon = max(agent.epsilon * 0.99, 0.01)\n",
     "        mean_rw_history.append(evaluate(make_env(), agent, n_games=3))\n",
     "    \n",


### PR DESCRIPTION
function 'load_weigths_into_target_network' create the  'assigns' tensor operators repeatedly when the function is called. These tensors are not gabage collected and bloats the memory along training.