### PR TITLE
Change submission URL to the one that is already deployed

### DIFF
--- a/grading.py
+++ b/grading.py
@@ -11,7 +11,7 @@ class Grader(object):
         Assignment key is the way to tell Coursera which problem is being submitted.
         """
         self.submission_page = \
-            'https://www.coursera.org/api/onDemandProgrammingScriptSubmissions.v1'
+            'https://hub.coursera-apps.org/api/onDemandProgrammingScriptSubmissions.v1'
         self.assignment_key = assignment_key
         self.answers = {part: None for part in all_parts}
 


### PR DESCRIPTION
Currently the version that is already deployed on Coursera contains this change. This PR brings it into the branch officially.

Note: this change was introduced before I started working on the project, so I would like to request review from people who are familiar with the reason for this change.