### PR TITLE
Fix nondeterministic behavior in tests

### DIFF
--- a/week2_model_based/practice_vi.ipynb
+++ b/week2_model_based/practice_vi.ipynb
@@ -147,7 +147,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "test_Vs = {s: i for i, s in enumerate(mdp.get_all_states())}\n",
+    "test_Vs = {s: i for i, s in enumerate(sorted(mdp.get_all_states()))}\n",
     "assert np.allclose(get_action_value(mdp, test_Vs, 's2', 'a1', 0.9), 0.69)\n",
     "assert np.allclose(get_action_value(mdp, test_Vs, 's1', 'a0', 0.9), 3.95)"
    ]

--- a/week2_model_based/submit.py
+++ b/week2_model_based/submit.py
@@ -49,7 +49,7 @@ def submit_assigment(
 
     mdp = MDP(transition_probs, rewards, initial_state='s0')
 
-    test_Vs = {s: i for i, s in enumerate(mdp.get_all_states())}
+    test_Vs = {s: i for i, s in enumerate(sorted(mdp.get_all_states()))}
     qvalue1 = get_action_value(mdp, test_Vs, 's1', 'a0', 0.9)
     qvalue2 = get_action_value(mdp, test_Vs, 's4', 'a1', 0.9)
 


### PR DESCRIPTION
As reported [on the forums](https://www.coursera.org/learn/practical-rl/discussions/all/threads/810KlEVyEemjVAr-CnpblA), the tests are currently non-deterministic and thus can fail randomly. This PR fixes two instances of that.

Please note that a similar fix has already been applied to the the [seminar notebook](https://github.com/yandexdataschool/Practical_RL/blob/spring19/week02_value_based/seminar_vi.ipynb) from week 2.

_Probably_ also fixes #144.