### PR TITLE
Remove redundant submission functions

### DIFF
--- a/week3_model_free/qlearning.ipynb
+++ b/week3_model_free/qlearning.ipynb
@@ -291,8 +291,6 @@
    },
    "outputs": [],
    "source": [
-    "# from submit import submit_qlearning1\n",
-    "# submit_qlearning1(rewards, <EMAIL>, <TOKEN>)\n",
     "submit_rewards1 = rewards.copy()"
    ]
   },
@@ -489,11 +487,19 @@
    },
    "outputs": [],
    "source": [
-    "# from submit import submit_qlearning2\n",
-    "# submit_qlearning2(rewards, <EMAIL>, <TOKEN>)\n",
-    "submit_rewards2 = rewards.copy()\n",
-    "from submit import submit_qlearning_all\n",
-    "submit_qlearning_all(submit_rewards1, submit_rewards2, <EMAIL>, <TOKEN>)"
+    "submit_rewards2 = rewards.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from submit import submit_qlearning\n",
+    "submit_qlearning(submit_rewards1, submit_rewards2, <EMAIL>, <TOKEN>)"
    ]
   }
  ],

--- a/week3_model_free/submit.py
+++ b/week3_model_free/submit.py
@@ -19,25 +19,7 @@ def submit_experience_replay(rewards_replay, rewards_baseline, email, token):
     grader.submit(email, token)
 
 
-def submit_qlearning1(rewards, email, token):
-    flag1 = np.mean(rewards[-10:])
-
-    grader = grading.Grader("XbjcGd7xEeeDzRKutDCmyA")
-    grader.set_answer("5NB4z", flag1)
-
-    grader.submit(email, token)
-
-
-def submit_qlearning2(rewards, email, token):
-    flag1 = np.mean(rewards[-10:])
-
-    grader = grading.Grader("XbjcGd7xEeeDzRKutDCmyA")
-    grader.set_answer("CkyJ4", flag1)
-
-    grader.submit(email, token)
-
-
-def submit_qlearning_all(rewards_q1, rewards_q2, email, token):
+def submit_qlearning(rewards_q1, rewards_q2, email, token):
     grader = grading.Grader("XbjcGd7xEeeDzRKutDCmyA")
 
     flag1 = np.mean(rewards_q1[-10:])


### PR DESCRIPTION
In #89, a fix was suggested for week3 submission. This fix was implemented and made two functions obsolete. This PR deletes these functions and renames a combined function (which was made default in `c5a6228`) from `submit_qlearning_all()` to just `submit_qlearning()`.