### PR TITLE
fixed typo  'latest_observations'

### DIFF
--- a/week06_policy_based/a2c-optional.ipynb
+++ b/week06_policy_based/a2c-optional.ipynb
@@ -162,7 +162,7 @@
     "\n",
     "In implementation, however, do not forget to use \n",
     "`trajectory['resets']` flags to check if you need to add the value targets at the next step when \n",
-    "computing value targets for the current step. You can access `trajectory['state']['latest_observations']`\n",
+    "computing value targets for the current step. You can access `trajectory['state']['latest_observation']`\n",
     "to get last observations in partial trajectory &mdash; $s_{t+T}$."
    ]
   },


### PR DESCRIPTION
Correct key for `trajectory['state']` in  "runners.py"  is ` 'latest_observation'`