### PR TITLE
Prevent warm_start same classes error

### DIFF
--- a/week01_intro/crossentropy_method.ipynb
+++ b/week01_intro/crossentropy_method.ipynb
@@ -416,14 +416,14 @@
    "source": [
     "# create agent\n",
     "from sklearn.neural_network import MLPClassifier\n",
+    "\n",
     "agent = MLPClassifier(\n",
     "    hidden_layer_sizes=(20, 20),\n",
     "    activation='tanh',\n",
-    "    warm_start=True,  # keep progress between .fit(...) calls\n",
-    "    max_iter=1,  # make only 1 iteration on each .fit(...)\n",
     ")\n",
-    "# initialize agent to the dimension of state an amount of actions\n",
-    "agent.fit([env.reset()]*n_actions, range(n_actions))"
+    "\n",
+    "# initialize agent to the dimension of state space and number of actions\n",
+    "agent.partial_fit([env.reset()] * n_actions, range(n_actions), range(n_actions))"
    ]
   },
   {
@@ -477,7 +477,7 @@
     "\n",
     "    elite_states, elite_actions = <select elite actions just like before>\n",
     "\n",
-    "    <fit agent to predict elite_actions(y) from elite_states(X)>\n",
+    "    <partial_fit agent to predict elite_actions(y) from elite_states(X)>\n",
     "\n",
     "    show_progress(rewards_batch, log, percentile, reward_range=[0, np.max(rewards_batch)])\n",
     "\n",


### PR DESCRIPTION
Using `warm_start` in conjunction with `max_iter=1` may result in the following error during a call to `fit()`:

```
ValueError: warm_start can only be used where `y` has the same classes as in the previous call to fit. Previously got [0 1], `y` has [0]
```

This is due to a certain peculiarity in `fit()` implementation which only arises if `y` happens to contain only one class by chance. `partial_fit()` is not affected by it, and, in fact, it is a superior option in terms of code cleanliness anyway.

Originally reported at the [Coursera forum](https://www.coursera.org/learn/practical-rl/discussions/all/threads/VNQ59ldoEeiTLBKb9DFnUA).