### PR TITLE
Apply autopep8 to all Python 3 scripts

### DIFF
--- a/week01_intro/pong.py
+++ b/week01_intro/pong.py
@@ -5,33 +5,37 @@ from scipy.misc import imresize
 from gym.core import Wrapper
 from gym.spaces.box import Box
 
+
 def make_pong():
     """creates breakout env with all preprocessing done for you"""
     return PreprocessAtari(gym.make("PongDeterministic-v0"))
 
+
 class PreprocessAtari(Wrapper):
-    def __init__(self,env,height=42,width=42,
-                 crop=lambda img: img[34:34+160],n_frames=4):
+    def __init__(self, env, height=42, width=42,
+                 crop=lambda img: img[34:34 + 160], n_frames=4):
         """A gym wrapper that reshapes, crops and scales image into the desired shapes"""
         super(PreprocessAtari, self).__init__(env)
-        self.img_size = (height,width)
-        self.crop=crop
-        self.observation_space = Box(0.0, 1.0, [n_frames,height,width])
-        self.framebuffer = np.zeros([n_frames,height,width])
+        self.img_size = (height, width)
+        self.crop = crop
+        self.observation_space = Box(0.0, 1.0, [n_frames, height, width])
+        self.framebuffer = np.zeros([n_frames, height, width])
+
     def reset(self):
         """resets breakout, returns initial frames"""
         self.framebuffer = np.zeros_like(self.framebuffer)
         self.update_buffer(self.env.reset())
         return self.framebuffer
-    def step(self,action):
+
+    def step(self, action):
         """plays breakout for 1 step, returns 4-frame buffer"""
-        new_img,r,done,info = self.env.step(action)
+        new_img, r, done, info = self.env.step(action)
         self.update_buffer(new_img)
-        return self.framebuffer,r,done,info
-    
+        return self.framebuffer, r, done, info
+
     ###image processing###
-    
-    def update_buffer(self,img):
+
+    def update_buffer(self, img):
         img = self.preproc_image(img)
         self.framebuffer = np.vstack([img[None], self.framebuffer[:-1]])
 
@@ -39,5 +43,5 @@ class PreprocessAtari(Wrapper):
         """what happens to the observation"""
         img = self.crop(img)
         img = imresize(img, self.img_size).mean(-1)
-        img = img.astype('float32')/255.
+        img = img.astype('float32') / 255.
         return img

--- a/week02_value_based/mdp.py
+++ b/week02_value_based/mdp.py
@@ -1,5 +1,6 @@
 # most of this code was politely stolen from https://github.com/berkeleydeeprlcourse/homework/
-# all credit goes to https://github.com/abhishekunique (if i got the author right)
+# all credit goes to https://github.com/abhishekunique (if i got the
+# author right)
 import sys
 import random
 import numpy as np
@@ -8,7 +9,7 @@ try:
     from graphviz import Digraph
     import graphviz
     has_graphviz = True
-except:
+except BaseException:
     has_graphviz = False
 
 
@@ -95,14 +96,16 @@ class MDP:
             self._current_state = self._initial_state()
         else:
             raise ValueError(
-                "initial state %s should be either a state or a function() -> state" % self._initial_state)
+                "initial state %s should be either a state or a function() -> state" %
+                self._initial_state)
         return self._current_state
 
     def step(self, action):
         """ take action, return next_state, reward, is_done, empty_info """
         possible_states, probs = zip(
             *self.get_next_states(self._current_state, action).items())
-        next_state = possible_states[np.random.choice(np.arange(len(possible_states)), p=probs)]
+        next_state = possible_states[np.random.choice(
+            np.arange(len(possible_states)), p=probs)]
         reward = self.get_reward(self._current_state, action, next_state)
         is_done = self.is_terminal(next_state)
         self._current_state = next_state
@@ -123,7 +126,7 @@ class MDP:
                                          "a dictionary but is instead %s" % (
                                              state, action,
                                              type(transition_probs[
-                                                      state, action]))
+                                                 state, action]))
                 next_state_probs = transition_probs[state][action]
                 assert len(
                     next_state_probs) != 0, "from state %s action %s leads to no next states" % (
@@ -231,7 +234,8 @@ class FrozenLakeEnv(MDP):
         transition_probs = {s: {} for s in states}
         rewards = {s: {} for s in states}
         for (row, col) in states:
-            if desc[row, col] in "GH": continue
+            if desc[row, col] in "GH":
+                continue
             for action_i in range(len(actions)):
                 action = actions[action_i]
                 transition_probs[(row, col)][action] = {}
@@ -241,10 +245,11 @@ class FrozenLakeEnv(MDP):
                     movement = actions[movement_i]
                     newrow, newcol = move(row, col, movement)
                     prob = (1. - slip_chance) if movement == action else (
-                            slip_chance / 2.)
-                    if prob == 0: continue
+                        slip_chance / 2.)
+                    if prob == 0:
+                        continue
                     if (newrow, newcol) not in transition_probs[row, col][
-                        action]:
+                            action]:
                         transition_probs[row, col][action][
                             newrow, newcol] = prob
                     else:
@@ -346,12 +351,14 @@ def plot_graph_with_state_values(mdp, state_values):
 
 def get_optimal_action_for_plot(mdp, state_values, state, gamma=0.9):
     """ Finds optimal action using formula above. """
-    if mdp.is_terminal(state): return None
+    if mdp.is_terminal(state):
+        return None
     next_actions = mdp.get_possible_actions(state)
     try:
         from mdp_get_action_value import get_action_value
     except ImportError:
-        raise ImportError("Implement get_action_value(mdp, state_values, state, action, gamma) in the file \"mdp_get_action_value.py\".")
+        raise ImportError(
+            "Implement get_action_value(mdp, state_values, state, action, gamma) in the file \"mdp_get_action_value.py\".")
     q_values = [get_action_value(mdp, state_values, state, action, gamma) for
                 action in next_actions]
     optimal_action = next_actions[np.argmax(q_values)]

--- a/week02_value_based/mdp.py
+++ b/week02_value_based/mdp.py
@@ -1,6 +1,6 @@
 # most of this code was politely stolen from https://github.com/berkeleydeeprlcourse/homework/
-# all credit goes to https://github.com/abhishekunique (if i got the
-# author right)
+# all credit goes to https://github.com/abhishekunique
+# (if I got the author right)
 import sys
 import random
 import numpy as np
@@ -9,7 +9,7 @@ try:
     from graphviz import Digraph
     import graphviz
     has_graphviz = True
-except BaseException:
+except ImportError:
     has_graphviz = False
 
 

--- a/week04_[recap]_deep_learning/mnist.py
+++ b/week04_[recap]_deep_learning/mnist.py
@@ -4,7 +4,8 @@ import time
 
 import numpy as np
 
-__doc__="""taken from https://github.com/Lasagne/Lasagne/blob/master/examples/mnist.py"""
+__doc__ = """taken from https://github.com/Lasagne/Lasagne/blob/master/examples/mnist.py"""
+
 
 def load_dataset():
     # We first define a download function, supporting both Python 2 and 3.
@@ -57,7 +58,3 @@ def load_dataset():
     # We just return all the arrays in order, as expected in main().
     # (It doesn't matter how we do this as long as we can read them again.)
     return X_train, y_train, X_val, y_val, X_test, y_test
-
-
-
-

--- a/week04_[recap]_deep_learning/notmnist.py
+++ b/week04_[recap]_deep_learning/notmnist.py
@@ -1,43 +1,51 @@
 import os
 import numpy as np
-from scipy.misc import imread,imresize
+from scipy.misc import imread, imresize
 from sklearn.model_selection import train_test_split
 from glob import glob
 
-def load_notmnist(path='./notMNIST_small',letters='ABCDEFGHIJ',
-                  img_shape=(28,28),test_size=0.25,one_hot=False):
-    
-    # download data if it's missing. If you have any problems, go to the urls and load it manually.
+
+def load_notmnist(path='./notMNIST_small', letters='ABCDEFGHIJ',
+                  img_shape=(28, 28), test_size=0.25, one_hot=False):
+
+    # download data if it's missing. If you have any problems, go to the urls
+    # and load it manually.
     if not os.path.exists(path):
         print("Downloading data...")
-        assert os.system('wget http://yaroslavvb.com/upload/notMNIST/notMNIST_small.tar.gz') == 0
+        assert os.system(
+            'wget http://yaroslavvb.com/upload/notMNIST/notMNIST_small.tar.gz') == 0
         print("Extracting ...")
-        assert os.system('tar -zxvf notMNIST_small.tar.gz > untar_notmnist.log') == 0
-    
-    data,labels = [],[]
+        assert os.system(
+            'tar -zxvf notMNIST_small.tar.gz > untar_notmnist.log') == 0
+
+    data, labels = [], []
     print("Parsing...")
-    for img_path in glob(os.path.join(path,'*/*')):
+    for img_path in glob(os.path.join(path, '*/*')):
         class_i = img_path.split(os.sep)[-2]
-        if class_i not in letters: continue
+        if class_i not in letters:
+            continue
         try:
             data.append(imresize(imread(img_path), img_shape))
             labels.append(class_i,)
-        except:
-            print("found broken img: %s [it's ok if <10 images are broken]" % img_path)
-        
-    data = np.stack(data)[:,None].astype('float32')
+        except BaseException:
+            print(
+                "found broken img: %s [it's ok if <10 images are broken]" %
+                img_path)
+
+    data = np.stack(data)[:, None].astype('float32')
     data = (data - np.mean(data)) / np.std(data)
 
-    #convert classes to ints
-    letter_to_i = {l:i for i,l in enumerate(letters)}
+    # convert classes to ints
+    letter_to_i = {l: i for i, l in enumerate(letters)}
     labels = np.array(list(map(letter_to_i.get, labels)))
-    
+
     if one_hot:
-        labels = (np.arange(np.max(labels) + 1)[None,:] == labels[:, None]).astype('float32')
-    
-    #split into train/test
-    X_train, X_test, y_train, y_test = train_test_split(data, labels, test_size=test_size, random_state=42)
-    
+        labels = (np.arange(np.max(labels) + 1)
+                  [None, :] == labels[:, None]).astype('float32')
+
+    # split into train/test
+    X_train, X_test, y_train, y_test = train_test_split(
+        data, labels, test_size=test_size, random_state=42)
+
     print("Done")
     return X_train, y_train, X_test, y_test
-

--- a/week04_approx_rl/atari_wrappers.py
+++ b/week04_approx_rl/atari_wrappers.py
@@ -3,13 +3,15 @@
 import numpy as np
 import gym
 
+
 class MaxAndSkipEnv(gym.Wrapper):
     def __init__(self, env, skip=4):
         """Return only every `skip`-th frame"""
         gym.Wrapper.__init__(self, env)
         # most recent raw observations (for max pooling across time steps)
-        self._obs_buffer = np.zeros((2,)+env.observation_space.shape, dtype=np.uint8)
-        self._skip       = skip
+        self._obs_buffer = np.zeros(
+            (2,) + env.observation_space.shape, dtype=np.uint8)
+        self._skip = skip
 
     def step(self, action):
         """Repeat action, sum reward, and max over last observations."""
@@ -17,8 +19,10 @@ class MaxAndSkipEnv(gym.Wrapper):
         done = None
         for i in range(self._skip):
             obs, reward, done, info = self.env.step(action)
-            if i == self._skip - 2: self._obs_buffer[0] = obs
-            if i == self._skip - 1: self._obs_buffer[1] = obs
+            if i == self._skip - 2:
+                self._obs_buffer[0] = obs
+            if i == self._skip - 1:
+                self._obs_buffer[1] = obs
             total_reward += reward
             if done:
                 break
@@ -69,7 +73,7 @@ class EpisodicLifeEnv(gym.Wrapper):
         """
         gym.Wrapper.__init__(self, env)
         self.lives = 0
-        self.was_real_done  = True
+        self.was_real_done = True
 
     def step(self, action):
         obs, reward, done, info = self.env.step(action)
@@ -105,8 +109,8 @@ class AntiTorchWrapper(gym.ObservationWrapper):
         gym.ObservationWrapper.__init__(self, env)
 
         self.img_size = [env.observation_space.shape[i]
-                           for i in [1, 2, 0]
-                        ]
+                         for i in [1, 2, 0]
+                         ]
         self.observation_space = gym.spaces.Box(0.0, 1.0, self.img_size)
 
     def _observation(self, img):

--- a/week04_approx_rl/framebuffer.py
+++ b/week04_approx_rl/framebuffer.py
@@ -1,6 +1,8 @@
 import numpy as np
 from gym.spaces.box import Box
 from gym.core import Wrapper
+
+
 class FrameBuffer(Wrapper):
     def __init__(self, env, n_frames=4, dim_order='tensorflow'):
         """A gym wrapper that reshapes, crops and scales image into the desired shapes"""
@@ -13,29 +15,31 @@ class FrameBuffer(Wrapper):
             n_channels, height, width = env.observation_space.shape
             obs_shape = [n_channels * n_frames, height, width]
         else:
-            raise ValueError('dim_order should be "tensorflow" or "pytorch", got {}'.format(dim_order))
+            raise ValueError(
+                'dim_order should be "tensorflow" or "pytorch", got {}'.format(dim_order))
         self.observation_space = Box(0.0, 1.0, obs_shape)
         self.framebuffer = np.zeros(obs_shape, 'float32')
-        
+
     def reset(self):
         """resets breakout, returns initial frames"""
         self.framebuffer = np.zeros_like(self.framebuffer)
         self.update_buffer(self.env.reset())
         return self.framebuffer
-    
+
     def step(self, action):
         """plays breakout for 1 step, returns frame buffer"""
         new_img, reward, done, info = self.env.step(action)
         self.update_buffer(new_img)
         return self.framebuffer, reward, done, info
-    
+
     def update_buffer(self, img):
         if self.dim_order == 'tensorflow':
             offset = self.env.observation_space.shape[-1]
             axis = -1
-            cropped_framebuffer = self.framebuffer[:,:,:-offset]
+            cropped_framebuffer = self.framebuffer[:, :, :-offset]
         elif self.dim_order == 'pytorch':
             offset = self.env.observation_space.shape[0]
             axis = 0
             cropped_framebuffer = self.framebuffer[:-offset]
-        self.framebuffer = np.concatenate([img, cropped_framebuffer], axis = axis)
+        self.framebuffer = np.concatenate(
+            [img, cropped_framebuffer], axis=axis)

--- a/week04_approx_rl/replay_buffer.py
+++ b/week04_approx_rl/replay_buffer.py
@@ -1,6 +1,8 @@
-# This code is shamelessly stolen from https://github.com/openai/baselines/blob/master/baselines/deepq/replay_buffer.py
+# This code is shamelessly stolen from
+# https://github.com/openai/baselines/blob/master/baselines/deepq/replay_buffer.py
 import numpy as np
 import random
+
 
 class ReplayBuffer(object):
     def __init__(self, size):
@@ -37,7 +39,8 @@ class ReplayBuffer(object):
             rewards.append(reward)
             obses_tp1.append(np.array(obs_tp1, copy=False))
             dones.append(done)
-        return np.array(obses_t), np.array(actions), np.array(rewards), np.array(obses_tp1), np.array(dones)
+        return np.array(obses_t), np.array(actions), np.array(
+            rewards), np.array(obses_tp1), np.array(dones)
 
     def sample(self, batch_size):
         """Sample a batch of experiences.
@@ -59,5 +62,6 @@ class ReplayBuffer(object):
             done_mask[i] = 1 if executing act_batch[i] resulted in
             the end of an episode and 0 otherwise.
         """
-        idxes = [random.randint(0, len(self._storage) - 1) for _ in range(batch_size)]
+        idxes = [random.randint(0, len(self._storage) - 1)
+                 for _ in range(batch_size)]
         return self._encode_sample(idxes)

--- a/week04_approx_rl/replay_buffer.py
+++ b/week04_approx_rl/replay_buffer.py
@@ -39,8 +39,13 @@ class ReplayBuffer(object):
             rewards.append(reward)
             obses_tp1.append(np.array(obs_tp1, copy=False))
             dones.append(done)
-        return np.array(obses_t), np.array(actions), np.array(
-            rewards), np.array(obses_tp1), np.array(dones)
+        return (
+            np.array(obses_t),
+            np.array(actions),
+            np.array(rewards),
+            np.array(obses_tp1),
+            np.array(dones)
+        )
 
     def sample(self, batch_size):
         """Sample a batch of experiences.
@@ -62,6 +67,8 @@ class ReplayBuffer(object):
             done_mask[i] = 1 if executing act_batch[i] resulted in
             the end of an episode and 0 otherwise.
         """
-        idxes = [random.randint(0, len(self._storage) - 1)
-                 for _ in range(batch_size)]
+        idxes = [
+            random.randint(0, len(self._storage) - 1)
+            for _ in range(batch_size)
+        ]
         return self._encode_sample(idxes)

--- a/week04_approx_rl/utils.py
+++ b/week04_approx_rl/utils.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 import os
 
+
 def get_cum_discounted_rewards(rewards, gamma):
     """
     evaluates cumulative discounted rewards:
@@ -36,7 +37,8 @@ def play_and_log_episode(env, agent, gamma=0.99, t_max=10000):
         v_agent.append(max_q_value)
         q_spreads.append(max_q_value - min_q_value)
         if step > 0:
-            td_errors.append(np.abs(rewards[-1] + gamma * v_agent[-1] - v_agent[-2]))
+            td_errors.append(
+                np.abs(rewards[-1] + gamma * v_agent[-1] - v_agent[-2]))
 
         action = qvalues.argmax(axis=-1)[0]
 
@@ -69,7 +71,7 @@ def img_by_obs(obs, state_dim):
     return obs.reshape([-1, state_dim[2]])
 
 
-def is_enough_ram(min_available_gb = 0.1):
+def is_enough_ram(min_available_gb=0.1):
     mem = psutil.virtual_memory()
     return mem.available >= min_available_gb * (1024 ** 3)
 
@@ -77,7 +79,8 @@ def is_enough_ram(min_available_gb = 0.1):
 def linear_decay(init_val, final_val, cur_step, total_steps):
     if cur_step >= total_steps:
         return final_val
-    return (init_val * (total_steps - cur_step) + final_val * cur_step) / total_steps
+    return (init_val * (total_steps - cur_step) +
+            final_val * cur_step) / total_steps
 
 
 def smoothen(values):

--- a/week05_explore/bayes.py
+++ b/week05_explore/bayes.py
@@ -16,15 +16,14 @@ from lasagne.random import get_rng
 
 from functools import wraps
 
-__all__ = ['NormalApproximation','get_var_cost','bbpwrap']
-
+__all__ = ['NormalApproximation', 'get_var_cost', 'bbpwrap']
 
 
 class NormalApproximation(object):
-    def __init__(self, mu=0, std=np.exp(-3),seed=None):
+    def __init__(self, mu=0, std=np.exp(-3), seed=None):
         """
         Approximation that samples network weights from factorized normal distribution.
-        
+
         :param mu: prior mean for gaussian weights
         :param std: prior std for gaussian weights
         :param seed: random seed
@@ -32,70 +31,84 @@ class NormalApproximation(object):
         self.prior_mu = mu
         self.prior_std = std
         self.srng = RandomStreams(seed or get_rng().randint(1, 2147462579))
-        
-    def log_normal(self,x, mean, std, eps=0.0):
+
+    def log_normal(self, x, mean, std, eps=0.0):
         """computes log-proba of normal distribution"""
         std += eps
-        return - 0.5 * np.log(2 * np.pi) - T.log(T.abs_(std)) - (x - mean) ** 2 / (2 * std ** 2)
+        return - 0.5 * np.log(2 * np.pi) - T.log(T.abs_(std)) - \
+            (x - mean) ** 2 / (2 * std ** 2)
 
     def log_prior(self, weights):
         """
-        Logarithm of prior probabilities for weights: 
+        Logarithm of prior probabilities for weights:
         log P(weights) aka log P(theta)
         """
         return self.log_normal(weights, self.prior_mu, self.prior_std)
 
-    def log_posterior_approx(self,weights, mean, rho):
+    def log_posterior_approx(self, weights, mean, rho):
         """
         Logarithm of ELBO on posterior probabilities:
         log q(weights|learned mu and rho) aka log q(theta|x)
         """
-        std = T.log1p(T.exp(rho))  #rho to std
+        std = T.log1p(T.exp(rho))  # rho to std
         return self.log_normal(weights, mean, std)
 
     def __call__(self, layer, spec, shape, name=None, **tags):
         # case when user uses default init specs
-        assert tags.get('variational',False) == True, "Please declare param as variational to avoid confusion"
-        
+        assert tags.get(
+            'variational', False), "Please declare param as variational to avoid confusion"
+
         if not isinstance(spec, dict):
-            initial_rho = np.log(np.expm1(self.prior_std))   #std to rho
-            assert np.isfinite(initial_rho),"too small std to initialize correctly. Please pass explicit"\
-                                            " initializer (dict with {'mu':mu_init, 'rho':rho_init})."
-            spec = {'mu': spec,'rho':init.Constant(initial_rho)}
-            
+            initial_rho = np.log(np.expm1(self.prior_std))  # std to rho
+            assert np.isfinite(initial_rho), "too small std to initialize correctly. Please pass explicit"\
+                " initializer (dict with {'mu':mu_init, 'rho':rho_init})."
+            spec = {'mu': spec, 'rho': init.Constant(initial_rho)}
 
-        mu_spec,rho_spec = spec['mu'],spec['rho']
-        
-        rho = layer.add_param(rho_spec, shape,name=(name or 'unk')+'.rho', **tags)
-        mean = layer.add_param(mu_spec, shape,name=(name or 'unk')+'.mu', **tags)
+        mu_spec, rho_spec = spec['mu'], spec['rho']
 
-        #Reparameterization trick
-        e = self.srng.normal(shape, std=1)  
-        W = mean + T.log1p(T.exp(rho)) * e 
+        rho = layer.add_param(
+            rho_spec, shape, name=(
+                name or 'unk') + '.rho', **tags)
+        mean = layer.add_param(
+            mu_spec, shape, name=(
+                name or 'unk') + '.mu', **tags)
 
-        #KL divergence KL(q,p) = E_(w~q(w|x)) [log q(w|x) - log P(w)] aka variational cost
-        q_p = T.sum(self.log_posterior_approx(W, mean, rho) - self.log_prior(W))
-            
-        #accumulate variational cost
+        # Reparameterization trick
+        e = self.srng.normal(shape, std=1)
+        W = mean + T.log1p(T.exp(rho)) * e
+
+        # KL divergence KL(q,p) = E_(w~q(w|x)) [log q(w|x) - log P(w)] aka
+        # variational cost
+        q_p = T.sum(
+            self.log_posterior_approx(
+                W,
+                mean,
+                rho) -
+            self.log_prior(W))
+
+        # accumulate variational cost
         layer._bbwrap_var_cost += q_p
         return W
 
 
-
-def get_var_cost(layer_or_layers,treat_as_input=None):
+def get_var_cost(layer_or_layers, treat_as_input=None):
     """
     Returns total variational cost aka KL(q(theta|x)||p(theta)) for all layers in the network
-    
+
     :param layer_or_layers: top layer(s) of your network, just like with lasagne.layers.get_output
     :param treat_as_input: don't accumulate over layers below these layers. See same param for lasagne.layers.get_all_layers
-    
+
     Alternatively, one can manually get weights for one layer via layer.get_var_cost()
     """
     cost = 0
-    for layer in lasagne.layers.get_all_layers(layer_or_layers,treat_as_input):
-        if hasattr(layer, 'get_var_cost'): #if layer is bayesian or pretends so
+    for layer in lasagne.layers.get_all_layers(
+            layer_or_layers, treat_as_input):
+        if hasattr(
+                layer,
+                'get_var_cost'):  # if layer is bayesian or pretends so
             cost += layer.get_var_cost()
     return cost
+
 
 def bbpwrap(approximation=NormalApproximation()):
     """
@@ -107,14 +120,18 @@ def bbpwrap(approximation=NormalApproximation()):
         pass
 
     """
-    
+
     def decorator(cls):
         def add_param_wrap(add_param):
             @wraps(add_param)
             def wrapped(self, spec, shape, name=None, **tags):
                 # we should take care about some user specification
                 # to avoid bbp hook just set tags['variational'] = True
-                if not tags.get('trainable', True) or tags.get('variational', False):
+                if not tags.get(
+                        'trainable',
+                        True) or tags.get(
+                        'variational',
+                        False):
                     return add_param(self, spec, shape, name, **tags)
                 else:
                     # we declare that params we add next
@@ -125,20 +142,18 @@ def bbpwrap(approximation=NormalApproximation()):
                     param = self.approximation(self, spec, shape, name, **tags)
                     return param
             return wrapped
-        
+
         def get_var_cost(self):
             """
             Returns total variational cost aka KL(q(theta|x)||p(theta)) for this layer.
             Alternatively, use function get_var_cost(layer) to get total cost for all layers below this one.
             """
             return self._bbwrap_var_cost
-        
 
         cls.approximation = approximation
-        cls._bbwrap_var_cost=0
+        cls._bbwrap_var_cost = 0
         cls.add_param = add_param_wrap(cls.add_param)
         cls.get_var_cost = get_var_cost
         return cls
-    
-    
+
     return decorator

--- a/week05_explore/bayes.py
+++ b/week05_explore/bayes.py
@@ -80,11 +80,9 @@ class NormalApproximation(object):
         # KL divergence KL(q,p) = E_(w~q(w|x)) [log q(w|x) - log P(w)] aka
         # variational cost
         q_p = T.sum(
-            self.log_posterior_approx(
-                W,
-                mean,
-                rho) -
-            self.log_prior(W))
+            self.log_posterior_approx(W, mean, rho) -
+            self.log_prior(W)
+        )
 
         # accumulate variational cost
         layer._bbwrap_var_cost += q_p
@@ -103,9 +101,8 @@ def get_var_cost(layer_or_layers, treat_as_input=None):
     cost = 0
     for layer in lasagne.layers.get_all_layers(
             layer_or_layers, treat_as_input):
-        if hasattr(
-                layer,
-                'get_var_cost'):  # if layer is bayesian or pretends so
+        if hasattr(layer, 'get_var_cost'):
+            # if layer is bayesian or pretends so
             cost += layer.get_var_cost()
     return cost
 
@@ -127,11 +124,8 @@ def bbpwrap(approximation=NormalApproximation()):
             def wrapped(self, spec, shape, name=None, **tags):
                 # we should take care about some user specification
                 # to avoid bbp hook just set tags['variational'] = True
-                if not tags.get(
-                        'trainable',
-                        True) or tags.get(
-                        'variational',
-                        False):
+                if not tags.get('trainable', True) or \
+                        tags.get('variational', False):
                     return add_param(self, spec, shape, name, **tags)
                 else:
                     # we declare that params we add next

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -13,295 +13,306 @@ cv2.ocl.setUseOpenCL(False)
 
 
 class EpisodicLife(gym.Wrapper):
-  """ Sets done flag to true when agent dies. """
-  def __init__(self, env):
-    super(EpisodicLife, self).__init__(env)
-    self.lives = 0
-    self.real_done = True
+    """ Sets done flag to true when agent dies. """
 
-  def step(self, action):
-    obs, rew, done, info = self.env.step(action)
-    self.real_done = done
-    info["real_done"] = done
-    lives = self.env.unwrapped.ale.lives()
-    if 0 < lives < self.lives:
-      done = True
-    self.lives = lives
-    return obs, rew, done, info
+    def __init__(self, env):
+        super(EpisodicLife, self).__init__(env)
+        self.lives = 0
+        self.real_done = True
 
-  def reset(self, **kwargs):
-    if self.real_done:
-      obs = self.env.reset(**kwargs)
-    else:
-      obs, _, _, _ = self.env.step(0)
-    self.lives = self.env.unwrapped.ale.lives()
-    return obs
+    def step(self, action):
+        obs, rew, done, info = self.env.step(action)
+        self.real_done = done
+        info["real_done"] = done
+        lives = self.env.unwrapped.ale.lives()
+        if 0 < lives < self.lives:
+            done = True
+        self.lives = lives
+        return obs, rew, done, info
+
+    def reset(self, **kwargs):
+        if self.real_done:
+            obs = self.env.reset(**kwargs)
+        else:
+            obs, _, _, _ = self.env.step(0)
+        self.lives = self.env.unwrapped.ale.lives()
+        return obs
 
 
 class FireReset(gym.Wrapper):
-  """ Makes fire action when reseting environment.
+    """ Makes fire action when reseting environment.
 
-  Some environments are fixed until the agent makes the fire action,
-  this wrapper makes this action so that the epsiode starts automatically.
-  """
-  def __init__(self, env):
-    super(FireReset, self).__init__(env)
-    action_meanings = env.unwrapped.get_action_meanings()
-    if len(action_meanings) < 3:
-      raise ValueError(
-          "env.unwrapped.get_action_meanings() must be of length >= 3"
-          f"but is of length {len(action_meanings)}")
-    if env.unwrapped.get_action_meanings()[1] != "FIRE":
-      raise ValueError(
-          "env.unwrapped.get_action_meanings() must have 'FIRE' "
-          f"under index 1, but is {action_meanings}")
+    Some environments are fixed until the agent makes the fire action,
+    this wrapper makes this action so that the epsiode starts automatically.
+    """
 
-  def step(self, action):
-    return self.env.step(action)
+    def __init__(self, env):
+        super(FireReset, self).__init__(env)
+        action_meanings = env.unwrapped.get_action_meanings()
+        if len(action_meanings) < 3:
+            raise ValueError(
+                "env.unwrapped.get_action_meanings() must be of length >= 3"
+                f"but is of length {len(action_meanings)}")
+        if env.unwrapped.get_action_meanings()[1] != "FIRE":
+            raise ValueError(
+                "env.unwrapped.get_action_meanings() must have 'FIRE' "
+                f"under index 1, but is {action_meanings}")
 
-  def reset(self, **kwargs):
-    self.env.reset(**kwargs)
-    obs, _, done, _ = self.env.step(1)
-    if done:
-      self.env.reset(**kwargs)
-    obs, _, done, _ = self.env.step(2)
-    if done:
-      self.env.reset(**kwargs)
-    return obs
+    def step(self, action):
+        return self.env.step(action)
+
+    def reset(self, **kwargs):
+        self.env.reset(**kwargs)
+        obs, _, done, _ = self.env.step(1)
+        if done:
+            self.env.reset(**kwargs)
+        obs, _, done, _ = self.env.step(2)
+        if done:
+            self.env.reset(**kwargs)
+        return obs
 
 
 class StartWithRandomActions(gym.Wrapper):
-  """ Makes random number of random actions at the beginning of each
-  episode. """
-  def __init__(self, env, max_random_actions=30):
-    super(StartWithRandomActions, self).__init__(env)
-    self.max_random_actions = max_random_actions
-    self.real_done = True
+    """ Makes random number of random actions at the beginning of each
+    episode. """
 
-  def step(self, action):
-    obs, rew, done, info = self.env.step(action)
-    self.real_done = info.get("real_done", True)
-    return obs, rew, done, info
+    def __init__(self, env, max_random_actions=30):
+        super(StartWithRandomActions, self).__init__(env)
+        self.max_random_actions = max_random_actions
+        self.real_done = True
 
-  def reset(self, **kwargs):
-    obs = self.env.reset()
-    if self.real_done:
-      num_random_actions = np.random.randint(self.max_random_actions + 1)
-      for _ in range(num_random_actions):
-        obs, _, _, _ = self.env.step(self.env.action_space.sample())
-      self.real_done = False
-    return obs
+    def step(self, action):
+        obs, rew, done, info = self.env.step(action)
+        self.real_done = info.get("real_done", True)
+        return obs, rew, done, info
+
+    def reset(self, **kwargs):
+        obs = self.env.reset()
+        if self.real_done:
+            num_random_actions = np.random.randint(self.max_random_actions + 1)
+            for _ in range(num_random_actions):
+                obs, _, _, _ = self.env.step(self.env.action_space.sample())
+            self.real_done = False
+        return obs
 
 
 class ImagePreprocessing(gym.ObservationWrapper):
-  """ Preprocesses image-observations by possibly grayscaling and resizing. """
-  def __init__(self, env, width=84, height=84, grayscale=True):
-    super(ImagePreprocessing, self).__init__(env)
-    self.width = width
-    self.height = height
-    self.grayscale = grayscale
-    ospace = self.env.observation_space
-    low, high, dtype = ospace.low.min(), ospace.high.max(), ospace.dtype
-    if self.grayscale:
-      self.observation_space = spaces.Box(low=low, high=high,
-                                          shape=(width, height), dtype=dtype)
-    else:
-      obs_shape = (width, height) + self.observation_space.shape[2:]
-      self.observation_space = spaces.Box(low=low, high=high,
-                                          shape=obs_shape, dtype=dtype)
+    """ Preprocesses image-observations by possibly grayscaling and resizing. """
 
-  def observation(self, observation):
-    """ Performs image preprocessing. """
-    if self.grayscale:
-      observation = cv2.cvtColor(observation, cv2.COLOR_RGB2GRAY)
-    observation = cv2.resize(observation, (self.width, self.height),
-                             cv2.INTER_AREA)
-    return observation
+    def __init__(self, env, width=84, height=84, grayscale=True):
+        super(ImagePreprocessing, self).__init__(env)
+        self.width = width
+        self.height = height
+        self.grayscale = grayscale
+        ospace = self.env.observation_space
+        low, high, dtype = ospace.low.min(), ospace.high.max(), ospace.dtype
+        if self.grayscale:
+            self.observation_space = spaces.Box(
+                low=low, high=high, shape=(
+                    width, height), dtype=dtype)
+        else:
+            obs_shape = (width, height) + self.observation_space.shape[2:]
+            self.observation_space = spaces.Box(low=low, high=high,
+                                                shape=obs_shape, dtype=dtype)
+
+    def observation(self, observation):
+        """ Performs image preprocessing. """
+        if self.grayscale:
+            observation = cv2.cvtColor(observation, cv2.COLOR_RGB2GRAY)
+        observation = cv2.resize(observation, (self.width, self.height),
+                                 cv2.INTER_AREA)
+        return observation
 
 
 class MaxBetweenFrames(gym.ObservationWrapper):
-  """ Takes maximum between two subsequent frames. """
-  def __init__(self, env):
-    if (isinstance(env.unwrapped, atari.AtariEnv) and
-        "NoFrameskip" not in env.spec.id):
-      raise ValueError("MaxBetweenFrames requires NoFrameskip in atari env id")
-    super(MaxBetweenFrames, self).__init__(env)
-    self.last_obs = None
+    """ Takes maximum between two subsequent frames. """
 
-  def observation(self, observation):
-    obs = np.maximum(observation, self.last_obs)
-    self.last_obs = observation
-    return obs
+    def __init__(self, env):
+        if (isinstance(env.unwrapped, atari.AtariEnv) and
+                "NoFrameskip" not in env.spec.id):
+            raise ValueError(
+                "MaxBetweenFrames requires NoFrameskip in atari env id")
+        super(MaxBetweenFrames, self).__init__(env)
+        self.last_obs = None
 
-  def reset(self, **kwargs):
-    self.last_obs = self.env.reset()
-    return self.last_obs
+    def observation(self, observation):
+        obs = np.maximum(observation, self.last_obs)
+        self.last_obs = observation
+        return obs
+
+    def reset(self, **kwargs):
+        self.last_obs = self.env.reset()
+        return self.last_obs
 
 
 class QueueFrames(gym.ObservationWrapper):
-  """ Queues specified number of frames together along new dimension. """
-  def __init__(self, env, nframes, concat=False):
-    super(QueueFrames, self).__init__(env)
-    self.obs_queue = deque([], maxlen=nframes)
-    self.concat = concat
-    ospace = self.observation_space
-    if self.concat:
-      oshape = ospace.shape[:-1] + (ospace.shape[-1] * nframes,)
-    else:
-      oshape = ospace.shape + (nframes,)
-    self.observation_space = spaces.Box(ospace.low.min(), ospace.high.max(),
-                                        oshape, ospace.dtype)
+    """ Queues specified number of frames together along new dimension. """
 
-  def observation(self, observation):
-    self.obs_queue.append(observation)
-    return (np.concatenate(self.obs_queue, -1) if self.concat
-            else np.dstack(self.obs_queue))
+    def __init__(self, env, nframes, concat=False):
+        super(QueueFrames, self).__init__(env)
+        self.obs_queue = deque([], maxlen=nframes)
+        self.concat = concat
+        ospace = self.observation_space
+        if self.concat:
+            oshape = ospace.shape[:-1] + (ospace.shape[-1] * nframes,)
+        else:
+            oshape = ospace.shape + (nframes,)
+        self.observation_space = spaces.Box(
+            ospace.low.min(), ospace.high.max(), oshape, ospace.dtype)
 
-  def reset(self, **kwargs):
-    obs = self.env.reset()
-    for _ in range(self.obs_queue.maxlen - 1):
-      self.obs_queue.append(obs)
-    return self.observation(obs)
+    def observation(self, observation):
+        self.obs_queue.append(observation)
+        return (np.concatenate(self.obs_queue, -1) if self.concat
+                else np.dstack(self.obs_queue))
+
+    def reset(self, **kwargs):
+        obs = self.env.reset()
+        for _ in range(self.obs_queue.maxlen - 1):
+            self.obs_queue.append(obs)
+        return self.observation(obs)
 
 
 class SkipFrames(gym.Wrapper):
-  """ Performs the same action for several steps and returns the final result.
-  """
-  def __init__(self, env, nskip=4):
-    super(SkipFrames, self).__init__(env)
-    if (isinstance(env.unwrapped, atari.AtariEnv) and
-        "NoFrameskip" not in env.spec.id):
-      raise ValueError("SkipFrames requires NoFrameskip in atari env id")
-    self.nskip = nskip
+    """ Performs the same action for several steps and returns the final result.
+    """
 
-  def step(self, action):
-    total_reward = 0.0
-    for _ in range(self.nskip):
-      obs, rew, done, info = self.env.step(action)
-      total_reward += rew
-      if done:
-        break
-    return obs, total_reward, done, info
+    def __init__(self, env, nskip=4):
+        super(SkipFrames, self).__init__(env)
+        if (isinstance(env.unwrapped, atari.AtariEnv) and
+                "NoFrameskip" not in env.spec.id):
+            raise ValueError("SkipFrames requires NoFrameskip in atari env id")
+        self.nskip = nskip
 
-  def reset(self, **kwargs):
-    return self.env.reset(**kwargs)
+    def step(self, action):
+        total_reward = 0.0
+        for _ in range(self.nskip):
+            obs, rew, done, info = self.env.step(action)
+            total_reward += rew
+            if done:
+                break
+        return obs, total_reward, done, info
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
 
 
 class ClipReward(gym.RewardWrapper):
-  """ Modifes reward to be in {-1, 0, 1} by taking sign of it. """
-  def reward(self, reward):
-    return np.sign(reward)
+    """ Modifes reward to be in {-1, 0, 1} by taking sign of it. """
+
+    def reward(self, reward):
+        return np.sign(reward)
 
 
 class TFSummaries(gym.Wrapper):
-  """ Writes env summaries."""
-  def __init__(self, env, prefix=None, running_mean_size=100, step_var=None):
-    super(TFSummaries, self).__init__(env)
-    self.episode_counter = 0
-    self.prefix = prefix or self.env.spec.id
-    self.step_var = (step_var if step_var is not None
-                     else tf.train.get_global_step())
+    """ Writes env summaries."""
 
-    nenvs = getattr(self.env.unwrapped, "nenvs", 1)
-    self.rewards = np.zeros(nenvs)
-    self.had_ended_episodes = np.zeros(nenvs, dtype=np.bool)
-    self.episode_lengths = np.zeros(nenvs)
-    self.reward_queues = [deque([], maxlen=running_mean_size)
-                          for _ in range(nenvs)]
+    def __init__(self, env, prefix=None, running_mean_size=100, step_var=None):
+        super(TFSummaries, self).__init__(env)
+        self.episode_counter = 0
+        self.prefix = prefix or self.env.spec.id
+        self.step_var = (step_var if step_var is not None
+                         else tf.train.get_global_step())
 
-  def should_write_summaries(self):
-    """ Returns true if it's time to write summaries. """
-    return np.all(self.had_ended_episodes)
+        nenvs = getattr(self.env.unwrapped, "nenvs", 1)
+        self.rewards = np.zeros(nenvs)
+        self.had_ended_episodes = np.zeros(nenvs, dtype=np.bool)
+        self.episode_lengths = np.zeros(nenvs)
+        self.reward_queues = [deque([], maxlen=running_mean_size)
+                              for _ in range(nenvs)]
 
-  def add_summaries(self):
-    """ Writes summaries. """
-    tf.contrib.summary.scalar(
-        f"{self.prefix}/total_reward",
-        tf.reduce_mean([q[-1] for q in self.reward_queues]),
-        step=self.step_var)
-    tf.contrib.summary.scalar(
-        f"{self.prefix}/reward_mean_{self.reward_queues[0].maxlen}",
-        tf.reduce_mean([np.mean(q) for q in self.reward_queues]),
-        step=self.step_var)
-    tf.contrib.summary.scalar(
-        f"{self.prefix}/episode_length",
-        tf.reduce_mean(self.episode_lengths),
-        step=self.step_var)
-    if self.had_ended_episodes.size > 1:
-      tf.contrib.summary.scalar(
-          f"{self.prefix}/min_reward",
-          min(q[-1] for q in self.reward_queues),
-          step=self.step_var)
-      tf.contrib.summary.scalar(
-          f"{self.prefix}/max_reward",
-          max(q[-1] for q in self.reward_queues),
-          step=self.step_var)
-    self.episode_lengths.fill(0)
-    self.had_ended_episodes.fill(False)
+    def should_write_summaries(self):
+        """ Returns true if it's time to write summaries. """
+        return np.all(self.had_ended_episodes)
 
-  def step(self, action):
-    obs, rew, done, info = self.env.step(action)
-    self.rewards += rew
-    self.episode_lengths[~self.had_ended_episodes] += 1
+    def add_summaries(self):
+        """ Writes summaries. """
+        tf.contrib.summary.scalar(
+            f"{self.prefix}/total_reward",
+            tf.reduce_mean([q[-1] for q in self.reward_queues]),
+            step=self.step_var)
+        tf.contrib.summary.scalar(
+            f"{self.prefix}/reward_mean_{self.reward_queues[0].maxlen}",
+            tf.reduce_mean([np.mean(q) for q in self.reward_queues]),
+            step=self.step_var)
+        tf.contrib.summary.scalar(
+            f"{self.prefix}/episode_length",
+            tf.reduce_mean(self.episode_lengths),
+            step=self.step_var)
+        if self.had_ended_episodes.size > 1:
+            tf.contrib.summary.scalar(
+                f"{self.prefix}/min_reward",
+                min(q[-1] for q in self.reward_queues),
+                step=self.step_var)
+            tf.contrib.summary.scalar(
+                f"{self.prefix}/max_reward",
+                max(q[-1] for q in self.reward_queues),
+                step=self.step_var)
+        self.episode_lengths.fill(0)
+        self.had_ended_episodes.fill(False)
 
-    info_collection = [info] if isinstance(info, dict) else info
-    done_collection = [done] if isinstance(done, bool) else done
-    done_indices = [i for i, info in enumerate(info_collection)
-                    if info.get("real_done", done_collection[i])]
-    for i in done_indices:
-      if not self.had_ended_episodes[i]:
-        self.had_ended_episodes[i] = True
-      self.reward_queues[i].append(self.rewards[i])
-      self.rewards[i] = 0
+    def step(self, action):
+        obs, rew, done, info = self.env.step(action)
+        self.rewards += rew
+        self.episode_lengths[~self.had_ended_episodes] += 1
 
-    if self.should_write_summaries():
-      self.add_summaries()
-    return obs, rew, done, info
+        info_collection = [info] if isinstance(info, dict) else info
+        done_collection = [done] if isinstance(done, bool) else done
+        done_indices = [i for i, info in enumerate(info_collection)
+                        if info.get("real_done", done_collection[i])]
+        for i in done_indices:
+            if not self.had_ended_episodes[i]:
+                self.had_ended_episodes[i] = True
+            self.reward_queues[i].append(self.rewards[i])
+            self.rewards[i] = 0
 
-  def reset(self, **kwargs):
-    self.rewards.fill(0)
-    self.episode_lengths.fill(0)
-    self.had_ended_episodes.fill(False)
-    return self.env.reset(**kwargs)
+        if self.should_write_summaries():
+            self.add_summaries()
+        return obs, rew, done, info
+
+    def reset(self, **kwargs):
+        self.rewards.fill(0)
+        self.episode_lengths.fill(0)
+        self.had_ended_episodes.fill(False)
+        return self.env.reset(**kwargs)
 
 
 def nature_dqn_env(env_id, nenvs=None, seed=None,
                    summaries=True, clip_reward=True):
-  """ Wraps env as in Nature DQN paper. """
-  if "NoFrameskip" not in env_id:
-    raise ValueError(f"env_id must have 'NoFrameskip' but is {env_id}")
-  if nenvs is not None:
-    if seed is None:
-      seed = list(range(nenvs))
-    if isinstance(seed, int):
-      seed = [seed] * nenvs
-    if len(seed) != nenvs:
-      raise ValueError(f"seed has length {len(seed)} but must have "
-                       f"length equal to nenvs which is {nenvs}")
+    """ Wraps env as in Nature DQN paper. """
+    if "NoFrameskip" not in env_id:
+        raise ValueError(f"env_id must have 'NoFrameskip' but is {env_id}")
+    if nenvs is not None:
+        if seed is None:
+            seed = list(range(nenvs))
+        if isinstance(seed, int):
+            seed = [seed] * nenvs
+        if len(seed) != nenvs:
+            raise ValueError(f"seed has length {len(seed)} but must have "
+                             f"length equal to nenvs which is {nenvs}")
 
-    env = ParallelEnvBatch([
-        lambda i=i, env_seed=env_seed: nature_dqn_env(
-            env_id, seed=env_seed, summaries=False, clip_reward=False)
-        for i, env_seed in enumerate(seed)
-    ])
+        env = ParallelEnvBatch([
+            lambda i=i, env_seed=env_seed: nature_dqn_env(
+                env_id, seed=env_seed, summaries=False, clip_reward=False)
+            for i, env_seed in enumerate(seed)
+        ])
+        if summaries:
+            env = TFSummaries(env, prefix=env_id)
+        if clip_reward:
+            env = ClipReward(env)
+        return env
+
+    env = gym.make(env_id)
+    env.seed(seed)
     if summaries:
-      env = TFSummaries(env, prefix=env_id)
+        env = TFSummaries(env)
+    env = EpisodicLife(env)
+    if "FIRE" in env.unwrapped.get_action_meanings():
+        env = FireReset(env)
+    env = StartWithRandomActions(env, max_random_actions=30)
+    env = MaxBetweenFrames(env)
+    env = SkipFrames(env, 4)
+    env = ImagePreprocessing(env, width=84, height=84, grayscale=True)
+    env = QueueFrames(env, 4)
     if clip_reward:
-      env = ClipReward(env)
+        env = ClipReward(env)
     return env
-
-  env = gym.make(env_id)
-  env.seed(seed)
-  if summaries:
-    env = TFSummaries(env)
-  env = EpisodicLife(env)
-  if "FIRE" in env.unwrapped.get_action_meanings():
-    env = FireReset(env)
-  env = StartWithRandomActions(env, max_random_actions=30)
-  env = MaxBetweenFrames(env)
-  env = SkipFrames(env, 4)
-  env = ImagePreprocessing(env, width=84, height=84, grayscale=True)
-  env = QueueFrames(env, 4)
-  if clip_reward:
-    env = ClipReward(env)
-  return env

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -108,8 +108,11 @@ class ImagePreprocessing(gym.ObservationWrapper):
         low, high, dtype = ospace.low.min(), ospace.high.max(), ospace.dtype
         if self.grayscale:
             self.observation_space = spaces.Box(
-                low=low, high=high, shape=(
-                    width, height), dtype=dtype)
+                low=low,
+                high=high,
+                shape=(width, height),
+                dtype=dtype,
+            )
         else:
             obs_shape = (width, height) + self.observation_space.shape[2:]
             self.observation_space = spaces.Box(low=low, high=high,

--- a/week06_policy_based/env_batch.py
+++ b/week06_policy_based/env_batch.py
@@ -105,9 +105,12 @@ class SingleEnvBatch(Wrapper, EnvBatch):
         ob, rew, done, info = self.env.step(actions[0])
         if done:
             ob = self.env.reset()
-        return ob[None], np.expand_dims(
-            rew, 0), np.expand_dims(
-            done, 0), [info]
+        return (
+            ob[None],
+            np.expand_dims(rew, 0),
+            np.expand_dims(done, 0),
+            [info],
+        )
 
     def reset(self):
         return self.env.reset()[None]

--- a/week06_policy_based/env_batch.py
+++ b/week06_policy_based/env_batch.py
@@ -6,196 +6,200 @@ import numpy as np
 
 
 class SpaceBatch(Space):
-  def __init__(self, spaces):
-    first_type = type(spaces[0])
-    first_shape = spaces[0].shape
-    first_dtype = spaces[0].dtype
-    for space in spaces:
-      if not isinstance(space, first_type):
-        raise TypeError("spaces have different types: {}, {}"
-                        .format(first_type, type(space)))
-      if first_shape != space.shape:
-        raise ValueError("spaces have different shapes: {}, {}"
-                         .format(first_shape, space.shape))
-      if first_dtype != space.dtype:
-        raise ValueError("spaces have different data types: {}, {}"
-                         .format(first_dtype, space.dtype))
+    def __init__(self, spaces):
+        first_type = type(spaces[0])
+        first_shape = spaces[0].shape
+        first_dtype = spaces[0].dtype
+        for space in spaces:
+            if not isinstance(space, first_type):
+                raise TypeError("spaces have different types: {}, {}"
+                                .format(first_type, type(space)))
+            if first_shape != space.shape:
+                raise ValueError("spaces have different shapes: {}, {}"
+                                 .format(first_shape, space.shape))
+            if first_dtype != space.dtype:
+                raise ValueError("spaces have different data types: {}, {}"
+                                 .format(first_dtype, space.dtype))
 
-    self.spaces = spaces
-    super(SpaceBatch, self).__init__(shape=self.spaces[0].shape,
-                                     dtype=self.spaces[0].dtype)
+        self.spaces = spaces
+        super(SpaceBatch, self).__init__(shape=self.spaces[0].shape,
+                                         dtype=self.spaces[0].dtype)
 
-  def sample(self):
-    return np.stack([space.sample() for space in self.spaces])
+    def sample(self):
+        return np.stack([space.sample() for space in self.spaces])
 
-  def __getattr__(self, attr):
-    return getattr(self.spaces[0], attr)
+    def __getattr__(self, attr):
+        return getattr(self.spaces[0], attr)
 
 
 class EnvBatch(Env):
-  def __init__(self, make_env, nenvs=None):
-    make_env_functions = self._get_make_env_functions(make_env, nenvs)
-    self._envs = [make_env() for make_env in make_env_functions]
-    self._nenvs = len(self.envs)
-    # self.observation_space = SpaceBatch([env.observation_space
-    #                                      for env in self._envs])
-    self.action_space = SpaceBatch([env.action_space
-                                    for env in self._envs])
+    def __init__(self, make_env, nenvs=None):
+        make_env_functions = self._get_make_env_functions(make_env, nenvs)
+        self._envs = [make_env() for make_env in make_env_functions]
+        self._nenvs = len(self.envs)
+        # self.observation_space = SpaceBatch([env.observation_space
+        #                                      for env in self._envs])
+        self.action_space = SpaceBatch([env.action_space
+                                        for env in self._envs])
 
-  def _get_make_env_functions(self, make_env, nenvs):
-    if nenvs is None and not isinstance(make_env, list):
-      raise ValueError("When nenvs is None make_env"
-                       " must be a list of callables")
-    if nenvs is not None and not callable(make_env):
-      raise ValueError("When nenvs is not None make_env must be callable")
+    def _get_make_env_functions(self, make_env, nenvs):
+        if nenvs is None and not isinstance(make_env, list):
+            raise ValueError("When nenvs is None make_env"
+                             " must be a list of callables")
+        if nenvs is not None and not callable(make_env):
+            raise ValueError(
+                "When nenvs is not None make_env must be callable")
 
-    if nenvs is not None:
-      make_env = [make_env for _ in range(nenvs)]
-    return make_env
+        if nenvs is not None:
+            make_env = [make_env for _ in range(nenvs)]
+        return make_env
 
-  @property
-  def nenvs(self):
-    return self._nenvs
+    @property
+    def nenvs(self):
+        return self._nenvs
 
-  @property
-  def envs(self):
-    return self._envs
+    @property
+    def envs(self):
+        return self._envs
 
-  def _check_actions(self, actions):
-    if not len(actions) == self.nenvs:
-      raise ValueError(
-          "number of actions is not equal to number of envs: "
-          "len(actions) = {}, nenvs = {}"
-          .format(len(actions), self.nenvs))
+    def _check_actions(self, actions):
+        if not len(actions) == self.nenvs:
+            raise ValueError(
+                "number of actions is not equal to number of envs: "
+                "len(actions) = {}, nenvs = {}"
+                .format(len(actions), self.nenvs))
 
-  def step(self, actions):
-    self._check_actions(actions)
-    obs, rews, resets, infos = [], [], [], []
-    for env, action in zip(self._envs, actions):
-      ob, rew, done, info = env.step(action)
-      if done:
-        ob = env.reset()
-      obs.append(ob)
-      rews.append(rew)
-      resets.append(done)
-      infos.append(info)
-    return np.stack(obs), np.stack(rews), np.stack(resets), infos
+    def step(self, actions):
+        self._check_actions(actions)
+        obs, rews, resets, infos = [], [], [], []
+        for env, action in zip(self._envs, actions):
+            ob, rew, done, info = env.step(action)
+            if done:
+                ob = env.reset()
+            obs.append(ob)
+            rews.append(rew)
+            resets.append(done)
+            infos.append(info)
+        return np.stack(obs), np.stack(rews), np.stack(resets), infos
 
-  def reset(self):
-    return np.stack([env.reset() for env in self.envs])
+    def reset(self):
+        return np.stack([env.reset() for env in self.envs])
 
 
 class SingleEnvBatch(Wrapper, EnvBatch):
-  def __init__(self, env):
-    super(SingleEnvBatch, self).__init__(env)
-    self.observation_space = SpaceBatch([self.env.observation_space])
-    self.action_space = SpaceBatch([self.env.action_space])
+    def __init__(self, env):
+        super(SingleEnvBatch, self).__init__(env)
+        self.observation_space = SpaceBatch([self.env.observation_space])
+        self.action_space = SpaceBatch([self.env.action_space])
 
-  @property
-  def nenvs(self):
-    return 1
+    @property
+    def nenvs(self):
+        return 1
 
-  @property
-  def envs(self):
-    return [self.env]
+    @property
+    def envs(self):
+        return [self.env]
 
-  def step(self, actions):
-    self._check_actions(actions)
-    ob, rew, done, info = self.env.step(actions[0])
-    if done:
-      ob = self.env.reset()
-    return ob[None], np.expand_dims(rew, 0), np.expand_dims(done, 0), [info]
+    def step(self, actions):
+        self._check_actions(actions)
+        ob, rew, done, info = self.env.step(actions[0])
+        if done:
+            ob = self.env.reset()
+        return ob[None], np.expand_dims(
+            rew, 0), np.expand_dims(
+            done, 0), [info]
 
-  def reset(self):
-    return self.env.reset()[None]
+    def reset(self):
+        return self.env.reset()[None]
 
 
 def worker(parent_connection, worker_connection, make_env_function,
            send_spaces=True):
-  # Adapted from SubprocVecEnv github.com/openai/baselines
-  parent_connection.close()
-  env = make_env_function()
-  if send_spaces:
-    worker_connection.send((env.observation_space, env.action_space))
-  while True:
-    cmd, action = worker_connection.recv()
-    if cmd == "step":
-      ob, rew, done, info = env.step(action)
-      if done:
-        ob = env.reset()
-      worker_connection.send((ob, rew, done, info))
-    elif cmd == "reset":
-      ob = env.reset()
-      worker_connection.send(ob)
-    elif cmd == "close":
-      env.close()
-      worker_connection.close()
-      break
-    else:
-      raise NotImplementedError("Unknown command %s" % cmd)
+    # Adapted from SubprocVecEnv github.com/openai/baselines
+    parent_connection.close()
+    env = make_env_function()
+    if send_spaces:
+        worker_connection.send((env.observation_space, env.action_space))
+    while True:
+        cmd, action = worker_connection.recv()
+        if cmd == "step":
+            ob, rew, done, info = env.step(action)
+            if done:
+                ob = env.reset()
+            worker_connection.send((ob, rew, done, info))
+        elif cmd == "reset":
+            ob = env.reset()
+            worker_connection.send(ob)
+        elif cmd == "close":
+            env.close()
+            worker_connection.close()
+            break
+        else:
+            raise NotImplementedError("Unknown command %s" % cmd)
 
 
 class ParallelEnvBatch(EnvBatch):
-  """
-  An abstract batch of environments.
-  """
-  def __init__(self, make_env, nenvs=None):
-    make_env_functions = self._get_make_env_functions(make_env, nenvs)
-    self._nenvs = len(make_env_functions)
-    self._parent_connections, self._worker_connections = zip(*[
-      Pipe() for _ in range(self._nenvs)
-    ])
-    self._processes = [
-        Process(
-          target=worker,
-          args=(parent_connection, worker_connection, make_env),
-          daemon=True
-        )
-        for i, (parent_connection, worker_connection, make_env)
-        in enumerate(zip(self._parent_connections,
-                         self._worker_connections,
-                         make_env_functions))
-    ]
-    for p in self._processes:
-      p.start()
-    self._closed = False
+    """
+    An abstract batch of environments.
+    """
 
-    for conn in self._worker_connections:
-      conn.close()
+    def __init__(self, make_env, nenvs=None):
+        make_env_functions = self._get_make_env_functions(make_env, nenvs)
+        self._nenvs = len(make_env_functions)
+        self._parent_connections, self._worker_connections = zip(*[
+            Pipe() for _ in range(self._nenvs)
+        ])
+        self._processes = [
+            Process(
+                target=worker,
+                args=(parent_connection, worker_connection, make_env),
+                daemon=True
+            )
+            for i, (parent_connection, worker_connection, make_env)
+            in enumerate(zip(self._parent_connections,
+                             self._worker_connections,
+                             make_env_functions))
+        ]
+        for p in self._processes:
+            p.start()
+        self._closed = False
 
-    observation_spaces, action_spaces = [], []
-    for conn in self._parent_connections:
-      ob_space, ac_space = conn.recv()
-      observation_spaces.append(ob_space)
-      action_spaces.append(ac_space)
-    self.observation_space = SpaceBatch(observation_spaces)
-    self.action_space = SpaceBatch(action_spaces)
+        for conn in self._worker_connections:
+            conn.close()
 
-  @property
-  def nenvs(self):
-    return self._nenvs
+        observation_spaces, action_spaces = [], []
+        for conn in self._parent_connections:
+            ob_space, ac_space = conn.recv()
+            observation_spaces.append(ob_space)
+            action_spaces.append(ac_space)
+        self.observation_space = SpaceBatch(observation_spaces)
+        self.action_space = SpaceBatch(action_spaces)
 
-  def step(self, actions):
-    self._check_actions(actions)
-    for conn, a in zip(self._parent_connections, actions):
-      conn.send(("step", a))
-    results = [conn.recv() for conn in self._parent_connections]
-    obs, rews, dones, infos = zip(*results)
-    return np.stack(obs), np.stack(rews), np.stack(dones), infos
+    @property
+    def nenvs(self):
+        return self._nenvs
 
-  def reset(self):
-    for conn in self._parent_connections:
-      conn.send(("reset", None))
-    return np.stack([conn.recv() for conn in self._parent_connections])
+    def step(self, actions):
+        self._check_actions(actions)
+        for conn, a in zip(self._parent_connections, actions):
+            conn.send(("step", a))
+        results = [conn.recv() for conn in self._parent_connections]
+        obs, rews, dones, infos = zip(*results)
+        return np.stack(obs), np.stack(rews), np.stack(dones), infos
 
-  def close(self):
-    if self._closed:
-      return
-    for conn in self._parent_connections:
-      conn.send(("close", None))
-    for p in self._processes:
-      p.join()
-    self._closed = True
+    def reset(self):
+        for conn in self._parent_connections:
+            conn.send(("reset", None))
+        return np.stack([conn.recv() for conn in self._parent_connections])
 
-  def render(self):
-    raise ValueError("render not defined for %s" % self)
+    def close(self):
+        if self._closed:
+            return
+        for conn in self._parent_connections:
+            conn.send(("close", None))
+        for p in self._processes:
+            p.join()
+        self._closed = True
+
+    def render(self):
+        raise ValueError("render not defined for %s" % self)

--- a/week06_policy_based/runners.py
+++ b/week06_policy_based/runners.py
@@ -1,60 +1,65 @@
 """ RL env runner """
 from collections import defaultdict
+
 import numpy as np
 
 
 class EnvRunner:
-  """ Reinforcement learning runner in an environment with given policy """
-  def __init__(self, env, policy, nsteps,
-               transforms=None, step_var=None):
-    self.env = env
-    self.policy = policy
-    self.nsteps = nsteps
-    self.transforms = transforms or []
-    self.step_var = step_var if step_var is not None else 0
-    self.state = {"latest_observation": self.env.reset()}
+    """ Reinforcement learning runner in an environment with given policy """
 
-  @property
-  def nenvs(self):
-    """ Returns number of batched envs or `None` if env is not batched """
-    return getattr(self.env.unwrapped, "nenvs", None)
+    def __init__(self, env, policy, nsteps, transforms=None, step_var=None):
+        self.env = env
+        self.policy = policy
+        self.nsteps = nsteps
+        self.transforms = transforms or []
+        self.step_var = step_var if step_var is not None else 0
+        self.state = {"latest_observation": self.env.reset()}
 
-  def reset(self):
-    """ Resets env and runner states. """
-    self.state["latest_observation"] = self.env.reset()
-    self.policy.reset()
+    @property
+    def nenvs(self):
+        """ Returns number of batched envs or `None` if env is not batched """
+        return getattr(self.env.unwrapped, "nenvs", None)
 
-  def get_next(self):
-    """ Runs the agent in the environment.  """
-    trajectory = defaultdict(list, {"actions": []})
-    observations = []
-    rewards = []
-    resets = []
-    self.state["env_steps"] = self.nsteps
-
-    for i in range(self.nsteps):
-      observations.append(self.state["latest_observation"])
-      act = self.policy.act(self.state["latest_observation"])
-      if "actions" not in act:
-        raise ValueError("result of policy.act must contain 'actions' "
-                         f"but has keys {list(act.keys())}")
-      for key, val in act.items():
-        trajectory[key].append(val)
-
-      obs, rew, done, _ = self.env.step(trajectory["actions"][-1])
-      self.state["latest_observation"] = obs
-      rewards.append(rew)
-      resets.append(done)
-      self.step_var += self.nenvs or 1
-
-      # Only reset if the env is not batched. Batched envs should auto-reset.
-      if not self.nenvs and np.all(done):
-        self.state["env_steps"] = i + 1
+    def reset(self):
+        """ Resets env and runner states. """
         self.state["latest_observation"] = self.env.reset()
+        self.policy.reset()
 
-    trajectory.update(observations=observations, rewards=rewards, resets=resets)
-    trajectory["state"] = self.state
+    def get_next(self):
+        """ Runs the agent in the environment.  """
+        trajectory = defaultdict(list, {"actions": []})
+        observations = []
+        rewards = []
+        resets = []
+        self.state["env_steps"] = self.nsteps
 
-    for transform in self.transforms:
-      transform(trajectory)
-    return trajectory
+        for i in range(self.nsteps):
+            observations.append(self.state["latest_observation"])
+            act = self.policy.act(self.state["latest_observation"])
+            if "actions" not in act:
+                raise ValueError("result of policy.act must contain 'actions' "
+                                 f"but has keys {list(act.keys())}")
+            for key, val in act.items():
+                trajectory[key].append(val)
+
+            obs, rew, done, _ = self.env.step(trajectory["actions"][-1])
+            self.state["latest_observation"] = obs
+            rewards.append(rew)
+            resets.append(done)
+            self.step_var += self.nenvs or 1
+
+            # Only reset if the env is not batched. Batched envs should
+            # auto-reset.
+            if not self.nenvs and np.all(done):
+                self.state["env_steps"] = i + 1
+                self.state["latest_observation"] = self.env.reset()
+
+        trajectory.update(
+            observations=observations,
+            rewards=rewards,
+            resets=resets)
+        trajectory["state"] = self.state
+
+        for transform in self.transforms:
+            transform(trajectory)
+        return trajectory

--- a/week07_seq2seq/basic_model_theano.py
+++ b/week07_seq2seq/basic_model_theano.py
@@ -27,10 +27,14 @@ class BasicTranslationModel:
         self.inp_voc = inp_voc
         self.out_voc = out_voc
         # encode input sequence
+
         class encoder:
             # intput layers
             inp = InputLayer((None, None))
-            mask = ExpressionLayer(inp, lambda x: get_mask_by_eos(T.eq(x, self.out_voc.eos_ix)))
+            mask = ExpressionLayer(
+                inp, lambda x: get_mask_by_eos(
+                    T.eq(
+                        x, self.out_voc.eos_ix)))
 
             # embed the tokens
             emb = EmbeddingLayer(inp, input_size=len(inp_voc),
@@ -39,7 +43,7 @@ class BasicTranslationModel:
             rnn_fw = GRULayer(emb, num_units=hid_size, mask_input=mask,
                               only_return_final=True)
 
-            dec_start = DenseLayer(rnn_fw,hid_size,nonlinearity=None)
+            dec_start = DenseLayer(rnn_fw, hid_size, nonlinearity=None)
 
         # make encoder a public field
         self.encoder = encoder
@@ -57,7 +61,8 @@ class BasicTranslationModel:
             logits = DenseLayer(new_hid, len(out_voc), nonlinearity=None)
 
             probs = NonlinearityLayer(logits, nonlinearity=T.nnet.softmax)
-            logprobs = NonlinearityLayer(logits, nonlinearity=T.nnet.logsoftmax)
+            logprobs = NonlinearityLayer(
+                logits, nonlinearity=T.nnet.logsoftmax)
             out = ProbabilisticResolver(probs, assume_normalized=True)
 
             state_dict = {
@@ -68,19 +73,21 @@ class BasicTranslationModel:
             }
 
             init_dict = {
-                new_hid:encoder.dec_start
+                new_hid: encoder.dec_start
                 # ^^^ this reads "before first step, new_hid is set to outputs of dec_start"
                 # if you add any more recurrent memory units with non-zero init
                 # please make sure they're here
             }
 
             nonseq_dict = {
-                # here you can add anything encoder needs that's gonna be same across time-steps
+                # here you can add anything encoder needs that's gonna be same
+                # across time-steps
             }
 
         self.decoder = decoder
 
-        top_layers = [encoder.dec_start,decoder.out] + list(decoder.state_dict.keys())
+        top_layers = [encoder.dec_start, decoder.out] + \
+            list(decoder.state_dict.keys())
         self.weights = get_all_params(top_layers, trainable=True)
 
     def symbolic_score(self, inp, out, eps=1e-30, **flags):
@@ -96,13 +103,13 @@ class BasicTranslationModel:
         therefore you can get likelihood as logprobas * tf.one_hot(out,n_tokens)
         """
 
-        l_output_sequence = InputLayer([None,None])
+        l_output_sequence = InputLayer([None, None])
 
         # Defining custom recurrent layer out of decoder
         rec = Recurrence(
             state_variables=self.decoder.state_dict,
             state_init=self.decoder.init_dict,
-            input_sequences={self.decoder.inp:l_output_sequence},
+            input_sequences={self.decoder.inp: l_output_sequence},
             input_nonsequences=self.decoder.nonseq_dict,
             tracked_outputs=self.decoder.logprobs,
             unroll_scan=False
@@ -117,19 +124,17 @@ class BasicTranslationModel:
 
         self.auto_updates = rec.get_automatic_updates()
         if len(self.auto_updates) != 0:
-            print("symbolic_score: Please collect auto_updates of random states "
-                  "after you called symbolic_score (available at model.auto_updates)!")
+            print(
+                "symbolic_score: Please collect auto_updates of random states "
+                "after you called symbolic_score (available at model.auto_updates)!")
 
-
-        first_logprobs = T.zeros_like(logprobs[:,:1])
-        logprobs = T.concatenate([first_logprobs,logprobs[:,:-1]],axis=1)
+        first_logprobs = T.zeros_like(logprobs[:, :1])
+        logprobs = T.concatenate([first_logprobs, logprobs[:, :-1]], axis=1)
 
         return logprobs
 
-
-
-    def symbolic_translate(self, inp, greedy=False, max_len = None,
-                           unroll_scan=False, eps = 1e-30, **flags):
+    def symbolic_translate(self, inp, greedy=False, max_len=None,
+                           unroll_scan=False, eps=1e-30, **flags):
         """
         takes symbolic int32 matrix of hebrew words, produces output tokens sampled
         from the model and output log-probabilities for all possible tokens at each tick.
@@ -143,13 +148,14 @@ class BasicTranslationModel:
                  log-probabilities of all tokens at each tick, [batch,time,n_tokens]
         """
         if unroll_scan:
-            assert isinstance(max_len,int), "if scan is unrolled, max_len must be a constant integer"
+            assert isinstance(
+                max_len, int), "if scan is unrolled, max_len must be a constant integer"
 
         max_len = max_len if max_len is not None else 2 * inp.shape[1]
 
         # initial output tokens (BOS)
         bos = T.zeros_like(inp[:, 0]) + self.out_voc.bos_ix
-        l_start = InputLayer((None,),bos)
+        l_start = InputLayer((None,), bos)
 
         # Defining custom recurrent layer out of decoder
         rec = Recurrence(
@@ -163,22 +169,23 @@ class BasicTranslationModel:
         )
 
         translations, logprobs = get_output(rec[self.decoder.out, self.decoder.logprobs],
-                                            {self.encoder.inp:inp,
-                                             l_start:bos},
-                                            recurrence_flags=dict(flags,greedy=greedy),
+                                            {self.encoder.inp: inp,
+                                             l_start: bos},
+                                            recurrence_flags=dict(flags, greedy=greedy),
                                             **flags)
 
         self.auto_updates = rec.get_automatic_updates()
         if len(self.auto_updates) != 0:
-            print("symbolic_translate: Please collect auto_updates of random states "
-                  "after you called symbolic_translate (available at model.auto_updates)!")
+            print(
+                "symbolic_translate: Please collect auto_updates of random states "
+                "after you called symbolic_translate (available at model.auto_updates)!")
 
         # add first step (bos)
-        translations = T.concatenate([bos[:,None],translations],axis=1)
-        first_logprobs = T.zeros_like(logprobs[:,:1])
-        logprobs = T.concatenate([first_logprobs,logprobs],axis=1)
+        translations = T.concatenate([bos[:, None], translations], axis=1)
+        first_logprobs = T.zeros_like(logprobs[:, :1])
+        logprobs = T.concatenate([first_logprobs, logprobs], axis=1)
 
-        return translations,logprobs
+        return translations, logprobs
 
 
 def merge_dicts(*dicts, **kwargs):
@@ -193,6 +200,6 @@ def merge_dicts(*dicts, **kwargs):
     for d in dicts:
         merged_dict.update(d)
     if kwargs.get('check_conflicts'):
-        assert len(merged_dict) == sum(map(len, dicts)), 'dicts have duplicate keys'
+        assert len(merged_dict) == sum(
+            map(len, dicts)), 'dicts have duplicate keys'
     return merged_dict
-

--- a/week07_seq2seq/basic_model_theano.py
+++ b/week07_seq2seq/basic_model_theano.py
@@ -32,16 +32,23 @@ class BasicTranslationModel:
             # intput layers
             inp = InputLayer((None, None))
             mask = ExpressionLayer(
-                inp, lambda x: get_mask_by_eos(
-                    T.eq(
-                        x, self.out_voc.eos_ix)))
+                inp,
+                lambda x: get_mask_by_eos(T.eq(x, self.out_voc.eos_ix)),
+            )
 
             # embed the tokens
-            emb = EmbeddingLayer(inp, input_size=len(inp_voc),
-                                 output_size=emb_size)
+            emb = EmbeddingLayer(
+                inp,
+                input_size=len(inp_voc),
+                output_size=emb_size,
+            )
 
-            rnn_fw = GRULayer(emb, num_units=hid_size, mask_input=mask,
-                              only_return_final=True)
+            rnn_fw = GRULayer(
+                emb,
+                num_units=hid_size,
+                mask_input=mask,
+                only_return_final=True,
+            )
 
             dec_start = DenseLayer(rnn_fw, hid_size, nonlinearity=None)
 
@@ -62,7 +69,9 @@ class BasicTranslationModel:
 
             probs = NonlinearityLayer(logits, nonlinearity=T.nnet.softmax)
             logprobs = NonlinearityLayer(
-                logits, nonlinearity=T.nnet.logsoftmax)
+                logits,
+                nonlinearity=T.nnet.logsoftmax,
+            )
             out = ProbabilisticResolver(probs, assume_normalized=True)
 
             state_dict = {

--- a/week07_seq2seq/basic_model_torch.py
+++ b/week07_seq2seq/basic_model_torch.py
@@ -67,8 +67,11 @@ class BasicTranslationModel(nn.Module):
         """
         device = next(self.parameters()).device
         batch_size = inp.shape[0]
-        bos = torch.tensor([self.out_voc.bos_ix] *
-                           batch_size, dtype=torch.long, device=device)
+        bos = torch.tensor(
+            [self.out_voc.bos_ix] * batch_size,
+            dtype=torch.long,
+            device=device,
+        )
         logits_seq = [torch.log(to_one_hot(bos, len(self.out_voc)) + eps)]
 
         hid_state = self.encode(inp, **flags)
@@ -91,8 +94,11 @@ class BasicTranslationModel(nn.Module):
         """
         device = next(self.parameters()).device
         batch_size = inp.shape[0]
-        bos = torch.tensor([self.out_voc.bos_ix] *
-                           batch_size, dtype=torch.long, device=device)
+        bos = torch.tensor(
+            [self.out_voc.bos_ix] * batch_size,
+            dtype=torch.long,
+            device=device,
+        )
         mask = torch.ones(batch_size, dtype=torch.uint8, device=device)
         logits_seq = [torch.log(to_one_hot(bos, len(self.out_voc)) + eps)]
         out_seq = [bos]
@@ -115,10 +121,10 @@ class BasicTranslationModel(nn.Module):
             if max_len and len(out_seq) >= max_len:
                 break
 
-        return torch.stack(
-            out_seq, 1), F.log_softmax(
-            torch.stack(
-                logits_seq, 1), dim=-1)
+        return (
+            torch.stack(out_seq, 1),
+            F.log_softmax(torch.stack(logits_seq, 1), dim=-1),
+        )
 
 
 ### Utility functions ###
@@ -173,9 +179,7 @@ def to_one_hot(y, n_dims=None):
     y_one_hot = torch.zeros(
         y_tensor.size()[0],
         n_dims,
-        device=y.device).scatter_(
-        1,
-        y_tensor,
-        1)
+        device=y.device,
+    ).scatter_(1, y_tensor, 1)
     y_one_hot = y_one_hot.view(*y.shape, -1)
     return y_one_hot

--- a/week07_seq2seq/voc.py
+++ b/week07_seq2seq/voc.py
@@ -22,8 +22,7 @@ class Vocab:
     @staticmethod
     def from_lines(lines, bos="__BOS__", eos="__EOS__", sep=''):
         flat_lines = sep.join(list(lines))
-        flat_lines = list(flat_lines.split(
-            sep)) if sep != '' else list(flat_lines)
+        flat_lines = list(flat_lines.split(sep)) if sep else list(flat_lines)
         tokens = list(set(sep.join(flat_lines)))
         tokens = [t for t in tokens if t not in (bos, eos) and len(t) != 0]
         tokens = [bos, eos] + tokens

--- a/week07_seq2seq/voc.py
+++ b/week07_seq2seq/voc.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class Vocab:
     def __init__(self, tokens, bos="__BOS__", eos="__EOS__", sep=''):
         """
@@ -7,7 +8,7 @@ class Vocab:
         """
         assert bos in tokens, eos in tokens
         self.tokens = tokens
-        self.token_to_ix = {t:i for i,t in enumerate(tokens)}
+        self.token_to_ix = {t: i for i, t in enumerate(tokens)}
 
         self.bos = bos
         self.bos_ix = self.token_to_ix[bos]
@@ -21,16 +22,17 @@ class Vocab:
     @staticmethod
     def from_lines(lines, bos="__BOS__", eos="__EOS__", sep=''):
         flat_lines = sep.join(list(lines))
-        flat_lines = list(flat_lines.split(sep)) if sep != '' else list(flat_lines)
+        flat_lines = list(flat_lines.split(
+            sep)) if sep != '' else list(flat_lines)
         tokens = list(set(sep.join(flat_lines)))
-        tokens = [t for t in tokens if t not in (bos,eos) and len(t) != 0]
-        tokens = [bos,eos] + tokens
-        return Vocab(tokens,bos,eos,sep)
+        tokens = [t for t in tokens if t not in (bos, eos) and len(t) != 0]
+        tokens = [bos, eos] + tokens
+        return Vocab(tokens, bos, eos, sep)
 
-    def tokenize(self,string):
+    def tokenize(self, string):
         """converts string to a list of tokens"""
-        tokens = list(filter(len,string.split(self.sep))) \
-                    if self.sep != '' else list(string)
+        tokens = list(filter(len, string.split(self.sep))) \
+            if self.sep != '' else list(string)
         return [self.bos] + tokens + [self.eos]
 
     def to_matrix(self, lines, max_len=None):
@@ -42,7 +44,7 @@ class Vocab:
          [30 21 15 15 21 14 28 27 13 -1 -1]
          [25 37 31 34 21 20 37 21 28 19 13]]
         """
-        max_len = max_len or max(map(len, lines)) + 2 # 2 for bos and eos
+        max_len = max_len or max(map(len, lines)) + 2  # 2 for bos and eos
 
         matrix = np.zeros((len(lines), max_len), dtype='int32') + self.eos_ix
         for i, seq in enumerate(lines):
@@ -60,7 +62,7 @@ class Vocab:
         :return:
         """
         lines = []
-        for line_ix in map(list,matrix):
+        for line_ix in map(list, matrix):
             if crop:
                 if line_ix[0] == self.bos_ix:
                     line_ix = line_ix[1:]

--- a/week08_pomdp/atari_util.py
+++ b/week08_pomdp/atari_util.py
@@ -5,37 +5,44 @@ from scipy.misc import imresize
 from gym.core import Wrapper
 from gym.spaces.box import Box
 
+
 class PreprocessAtari(Wrapper):
     def __init__(self, env, height=42, width=42, color=False,
                  crop=lambda img: img, n_frames=4, dim_order='theano'):
         """A gym wrapper that reshapes, crops and scales image into the desired shapes"""
         super(PreprocessAtari, self).__init__(env)
         assert dim_order in ('theano', 'tensorflow')
-        self.img_size = (height,width)
-        self.crop=crop
-        self.color=color
+        self.img_size = (height, width)
+        self.crop = crop
+        self.color = color
         self.dim_order = dim_order
-        
+
         n_channels = (3 * n_frames) if color else n_frames
-        obs_shape = [n_channels,height,width] if dim_order == 'theano' else [height,width,n_channels]
+        obs_shape = [
+            n_channels,
+            height,
+            width] if dim_order == 'theano' else [
+            height,
+            width,
+            n_channels]
         self.observation_space = Box(0.0, 1.0, obs_shape)
         self.framebuffer = np.zeros(obs_shape, 'float32')
-        
+
     def reset(self):
         """resets breakout, returns initial frames"""
         self.framebuffer = np.zeros_like(self.framebuffer)
         self.update_buffer(self.env.reset())
         return self.framebuffer
-    
-    def step(self,action):
+
+    def step(self, action):
         """plays breakout for 1 step, returns frame buffer"""
-        new_img,r,done,info = self.env.step(action)
+        new_img, r, done, info = self.env.step(action)
         self.update_buffer(new_img)
-        return self.framebuffer,r,done,info
-    
+        return self.framebuffer, r, done, info
+
     ### image processing ###
-    
-    def update_buffer(self,img):
+
+    def update_buffer(self, img):
         img = self.preproc_image(img)
         offset = 3 if self.color else 1
         if self.dim_order == 'theano':
@@ -43,8 +50,9 @@ class PreprocessAtari(Wrapper):
             cropped_framebuffer = self.framebuffer[:-offset]
         else:
             axis = -1
-            cropped_framebuffer = self.framebuffer[:,:,:-offset]
-        self.framebuffer = np.concatenate([img, cropped_framebuffer], axis = axis)
+            cropped_framebuffer = self.framebuffer[:, :, :-offset]
+        self.framebuffer = np.concatenate(
+            [img, cropped_framebuffer], axis=axis)
 
     def preproc_image(self, img):
         """what happens to the observation"""
@@ -53,6 +61,6 @@ class PreprocessAtari(Wrapper):
         if not self.color:
             img = img.mean(-1, keepdims=True)
         if self.dim_order == 'theano':
-            img = img.transpose([2,0,1]) # [h, w, c] to [c, h, w]
-        img = img.astype('float32')/255.
+            img = img.transpose([2, 0, 1])  # [h, w, c] to [c, h, w]
+        img = img.astype('float32') / 255.
         return img

--- a/week08_pomdp/atari_util.py
+++ b/week08_pomdp/atari_util.py
@@ -1,9 +1,8 @@
 """Auxilary files for those who wanted to solve breakout with CEM or policy gradient"""
 import numpy as np
-import gym
-from scipy.misc import imresize
 from gym.core import Wrapper
 from gym.spaces.box import Box
+from skimage.transform import resize
 
 
 class PreprocessAtari(Wrapper):
@@ -18,13 +17,10 @@ class PreprocessAtari(Wrapper):
         self.dim_order = dim_order
 
         n_channels = (3 * n_frames) if color else n_frames
-        obs_shape = [
-            n_channels,
-            height,
-            width] if dim_order == 'theano' else [
-            height,
-            width,
-            n_channels]
+        obs_shape = \
+            [n_channels, height, width] \
+            if dim_order == 'theano' else \
+            [height, width, n_channels]
         self.observation_space = Box(0.0, 1.0, obs_shape)
         self.framebuffer = np.zeros(obs_shape, 'float32')
 
@@ -57,7 +53,7 @@ class PreprocessAtari(Wrapper):
     def preproc_image(self, img):
         """what happens to the observation"""
         img = self.crop(img)
-        img = imresize(img, self.img_size)
+        img = resize(img, self.img_size)
         if not self.color:
             img = img.mean(-1, keepdims=True)
         if self.dim_order == 'theano':

--- a/week08_pomdp/env_pool.py
+++ b/week08_pomdp/env_pool.py
@@ -46,8 +46,8 @@ class EnvPool(object):
 
         def env_step(i, action):
             if not self.just_ended[i]:
-                new_observation, cur_reward, is_done, info = self.envs[i].step(
-                    action)
+                new_observation, cur_reward, is_done, info = \
+                    self.envs[i].step(action)
                 if is_done:
                     # Game ends now, will finalize on next tick.
                     self.just_ended[i] = True
@@ -103,10 +103,9 @@ class EnvPool(object):
         # cast to numpy arrays, transpose from [time, batch, ...] to [batch,
         # time, ...]
         history_log = [
-            np.array(tensor).swapaxes(
-                0,
-                1) for tensor in zip(
-                *history_log)]
+            np.array(tensor).swapaxes(0, 1)
+            for tensor in zip(*history_log)
+        ]
         observation_seq, action_seq, reward_seq, is_alive_seq = history_log
 
         return observation_seq, action_seq, reward_seq, is_alive_seq

--- a/week08_pomdp/env_pool.py
+++ b/week08_pomdp/env_pool.py
@@ -6,6 +6,8 @@ interaction sessions given agent one-step applier function.
 import numpy as np
 
 # A whole lot of space invaders
+
+
 class EnvPool(object):
     def __init__(self, agent, make_env, n_parallel_games=1):
         """
@@ -28,7 +30,8 @@ class EnvPool(object):
         # Agent memory variables (if you use recurrent networks).
         self.prev_memory_states = agent.get_initial_state(n_parallel_games)
 
-        # Whether particular session has just been terminated and needs restarting.
+        # Whether particular session has just been terminated and needs
+        # restarting.
         self.just_ended = [False] * len(self.envs)
 
     def interact(self, n_steps=100, verbose=False):
@@ -43,19 +46,23 @@ class EnvPool(object):
 
         def env_step(i, action):
             if not self.just_ended[i]:
-                new_observation, cur_reward, is_done, info = self.envs[i].step(action)
+                new_observation, cur_reward, is_done, info = self.envs[i].step(
+                    action)
                 if is_done:
                     # Game ends now, will finalize on next tick.
                     self.just_ended[i] = True
 
-                # note: is_alive=True in any case because environment is still alive (last tick alive) in our notation.
+                # note: is_alive=True in any case because environment is still
+                # alive (last tick alive) in our notation.
                 return new_observation, cur_reward, True, info
             else:
-                # Reset environment, get new observation to be used on next tick.
+                # Reset environment, get new observation to be used on next
+                # tick.
                 new_observation = self.envs[i].reset()
 
                 # Reset memory for new episode.
-                initial_memory_state = self.agent.get_initial_state(batch_size=1)
+                initial_memory_state = self.agent.get_initial_state(
+                    batch_size=1)
                 for m_i in range(len(new_memory_states)):
                     new_memory_states[m_i][i] = initial_memory_state[m_i][0]
 
@@ -69,25 +76,37 @@ class EnvPool(object):
         history_log = []
 
         for i in range(n_steps - 1):
-            new_memory_states, readout = self.agent.step(self.prev_memory_states, self.prev_observations)
+            new_memory_states, readout = self.agent.step(
+                self.prev_memory_states, self.prev_observations)
             actions = self.agent.sample_actions(readout)
 
-            new_observations, cur_rewards, is_alive, infos = zip(*map(env_step, range(len(self.envs)), actions))
+            new_observations, cur_rewards, is_alive, infos = zip(
+                *map(env_step, range(len(self.envs)), actions))
 
             # Append data tuple for this tick.
-            history_log.append((self.prev_observations, actions, cur_rewards, is_alive))
+            history_log.append(
+                (self.prev_observations, actions, cur_rewards, is_alive))
 
             self.prev_observations = new_observations
             self.prev_memory_states = new_memory_states
-        
-        #add last observation
+
+        # add last observation
         dummy_actions = [0] * len(self.envs)
         dummy_rewards = [0] * len(self.envs)
         dummy_mask = [1] * len(self.envs)
-        history_log.append((self.prev_observations, dummy_actions, dummy_rewards, dummy_mask))
+        history_log.append(
+            (self.prev_observations,
+             dummy_actions,
+             dummy_rewards,
+             dummy_mask))
 
-        # cast to numpy arrays, transpose from [time, batch, ...] to [batch, time, ...]
-        history_log = [np.array(tensor).swapaxes(0, 1) for tensor in zip(*history_log)]
+        # cast to numpy arrays, transpose from [time, batch, ...] to [batch,
+        # time, ...]
+        history_log = [
+            np.array(tensor).swapaxes(
+                0,
+                1) for tensor in zip(
+                *history_log)]
         observation_seq, action_seq, reward_seq, is_alive_seq = history_log
 
         return observation_seq, action_seq, reward_seq, is_alive_seq

--- a/week09_policy_II/mujoco_wrappers.py
+++ b/week09_policy_II/mujoco_wrappers.py
@@ -5,93 +5,95 @@ import numpy as np
 
 
 class RunningMeanVar:
-  """ Computes running mean and variance.
+    """ Computes running mean and variance.
 
-  Args:
-    eps (float): a small constant used to initialize mean to zero and
-      variance to 1.
-    shape tuple(int): shape of the statistics.
-  """
+    Args:
+      eps (float): a small constant used to initialize mean to zero and
+        variance to 1.
+      shape tuple(int): shape of the statistics.
+    """
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
-  def __init__(self, eps=1e-4, shape=()):
-    self.mean = np.zeros(shape)
-    self.var = np.ones(shape)
-    self.count = eps
 
-  def update(self, batch):
-    """ Updates the running statistics given a batch of samples. """
-    if not batch.shape[1:] == self.mean.shape:
-      raise ValueError(f"batch has invalid shape: {batch.shape}, "
-                       f"expected shape {(None,) + self.mean.shape}")
-    batch_mean = np.mean(batch, axis=0)
-    batch_var = np.var(batch, axis=0)
-    batch_count = batch.shape[0]
-    self.update_from_moments(batch_mean, batch_var, batch_count)
+    def __init__(self, eps=1e-4, shape=()):
+        self.mean = np.zeros(shape)
+        self.var = np.ones(shape)
+        self.count = eps
 
-  def update_from_moments(self, batch_mean, batch_var, batch_count):
-    """ Updates the running statistics given their new values on new data. """
-    self.mean, self.var, self.count = update_mean_var_count_from_moments(
-        self.mean, self.var, self.count, batch_mean, batch_var, batch_count)
+    def update(self, batch):
+        """ Updates the running statistics given a batch of samples. """
+        if not batch.shape[1:] == self.mean.shape:
+            raise ValueError(f"batch has invalid shape: {batch.shape}, "
+                             f"expected shape {(None,) + self.mean.shape}")
+        batch_mean = np.mean(batch, axis=0)
+        batch_var = np.var(batch, axis=0)
+        batch_count = batch.shape[0]
+        self.update_from_moments(batch_mean, batch_var, batch_count)
+
+    def update_from_moments(self, batch_mean, batch_var, batch_count):
+        """ Updates the running statistics given their new values on new data. """
+        self.mean, self.var, self.count = update_mean_var_count_from_moments(
+            self.mean, self.var, self.count, batch_mean, batch_var, batch_count)
 
 
 def update_mean_var_count_from_moments(mean, var, count,
                                        batch_mean, batch_var, batch_count):
-  """ Updates running mean statistics given a new batch. """
-  delta = batch_mean - mean
-  tot_count = count + batch_count
+    """ Updates running mean statistics given a new batch. """
+    delta = batch_mean - mean
+    tot_count = count + batch_count
 
-  new_mean = mean + delta * batch_count / tot_count
-  new_var = (
-      var * (count / tot_count)
-      + batch_var * (batch_count / tot_count)
-      + np.square(delta) * (count * batch_count / tot_count ** 2))
-  new_count = tot_count
+    new_mean = mean + delta * batch_count / tot_count
+    new_var = (
+        var * (count / tot_count)
+        + batch_var * (batch_count / tot_count)
+        + np.square(delta) * (count * batch_count / tot_count ** 2))
+    new_count = tot_count
 
-  return new_mean, new_var, new_count
+    return new_mean, new_var, new_count
 
 
 class Normalize(gym.Wrapper):
-  """
-  A vectorized wrapper that normalizes the observations
-  and returns from an environment.
-  """
-  # pylint: disable=too-many-arguments
-  def __init__(self, env, obs=True, ret=True,
-               clipobs=10., cliprew=10., gamma=0.99, eps=1e-8):
-    super().__init__(env)
-    self.obs_rmv = (RunningMeanVar(shape=self.observation_space.shape)
-                    if obs else None)
-    self.ret_rmv = RunningMeanVar(shape=()) if ret else None
-    self.clipob = clipobs
-    self.cliprew = cliprew
-    self.ret = np.zeros(getattr(self.env.unwrapped, "nenvs", 1))
-    self.gamma = gamma
-    self.eps = eps
+    """
+    A vectorized wrapper that normalizes the observations
+    and returns from an environment.
+    """
+    # pylint: disable=too-many-arguments
 
-  def observation(self, obs):
-    """ Preprocesses a given observation. """
-    if not self.obs_rmv:
-      return obs
-    rmv_batch = (np.expand_dims(obs, 0)
-                 if not hasattr(self.env.unwrapped, "nenvs")
-                 else obs)
-    self.obs_rmv.update(rmv_batch)
-    obs = (obs - self.obs_rmv.mean) / np.sqrt(self.obs_rmv.var + self.eps)
-    obs = np.clip(obs, -self.clipob, self.clipob)
-    return obs
+    def __init__(self, env, obs=True, ret=True,
+                 clipobs=10., cliprew=10., gamma=0.99, eps=1e-8):
+        super().__init__(env)
+        self.obs_rmv = (RunningMeanVar(shape=self.observation_space.shape)
+                        if obs else None)
+        self.ret_rmv = RunningMeanVar(shape=()) if ret else None
+        self.clipob = clipobs
+        self.cliprew = cliprew
+        self.ret = np.zeros(getattr(self.env.unwrapped, "nenvs", 1))
+        self.gamma = gamma
+        self.eps = eps
 
-  def step(self, action):
-    obs, rews, resets, info = self.env.step(action)
-    self.ret = self.ret * self.gamma + rews
-    obs = self.observation(obs)
-    if self.ret_rmv:
-      self.ret_rmv.update(self.ret)
-      rews = np.clip(rews / np.sqrt(self.ret_rmv.var + self.eps),
-                     -self.cliprew, self.cliprew)
-    self.ret[resets] = 0.
-    return obs, rews, resets, info
+    def observation(self, obs):
+        """ Preprocesses a given observation. """
+        if not self.obs_rmv:
+            return obs
+        rmv_batch = (np.expand_dims(obs, 0)
+                     if not hasattr(self.env.unwrapped, "nenvs")
+                     else obs)
+        self.obs_rmv.update(rmv_batch)
+        obs = (obs - self.obs_rmv.mean) / np.sqrt(self.obs_rmv.var + self.eps)
+        obs = np.clip(obs, -self.clipob, self.clipob)
+        return obs
 
-  def reset(self, **kwargs):
-    self.ret = np.zeros(getattr(self.env.unwrapped, "nenvs", 1))
-    obs = self.env.reset(**kwargs)
-    return self.observation(obs)
+    def step(self, action):
+        obs, rews, resets, info = self.env.step(action)
+        self.ret = self.ret * self.gamma + rews
+        obs = self.observation(obs)
+        if self.ret_rmv:
+            self.ret_rmv.update(self.ret)
+            rews = np.clip(rews / np.sqrt(self.ret_rmv.var + self.eps),
+                           -self.cliprew, self.cliprew)
+        self.ret[resets] = 0.
+        return obs, rews, resets, info
+
+    def reset(self, **kwargs):
+        self.ret = np.zeros(getattr(self.env.unwrapped, "nenvs", 1))
+        obs = self.env.reset(**kwargs)
+        return self.observation(obs)


### PR DESCRIPTION
I ran `autopep8 -i -a -a -a -r .` in the repo root and fixed manually everything I found unsatisfactory.

The diff is best viewed with the "ignore whitespace changes" option.