### PR TITLE
Fix tests after changing MDP structure

### DIFF
--- a/week02_value_based/seminar_vi.ipynb
+++ b/week02_value_based/seminar_vi.ipynb
@@ -444,8 +444,8 @@
    "source": [
     "import numpy as np\n",
     "test_Vs = {s: i for i, s in enumerate(sorted(mdp.get_all_states()))}\n",
-    "assert np.allclose(get_action_value(mdp, test_Vs, 's2', 'a1', 0.9), 0.69)\n",
-    "assert np.allclose(get_action_value(mdp, test_Vs, 's1', 'a0', 0.9), 3.95)"
+    "assert np.isclose(get_action_value(mdp, test_Vs, 's2', 'a1', 0.9), 0.69)\n",
+    "assert np.isclose(get_action_value(mdp, test_Vs, 's1', 'a0', 0.9), 3.95)"
    ]
   },
   {
@@ -490,8 +490,8 @@
    "outputs": [],
    "source": [
     "test_Vs_copy = dict(test_Vs)\n",
-    "assert np.allclose(get_new_state_value(mdp, test_Vs, 's0', 0.9), 1.8)\n",
-    "assert np.allclose(get_new_state_value(mdp, test_Vs, 's2', 0.9), 0.69)\n",
+    "assert np.isclose(get_new_state_value(mdp, test_Vs, 's0', 0.9), 1.8)\n",
+    "assert np.isclose(get_new_state_value(mdp, test_Vs, 's2', 0.9), 1.08)\n",
     "assert test_Vs == test_Vs_copy, \"please do not change state_values in get_new_state_value\""
    ]
   },
@@ -538,8 +538,7 @@
     "    diff = max(abs(new_state_values[s] - state_values[s])\n",
     "               for s in mdp.get_all_states())\n",
     "    print(\"iter %4i   |   diff: %6.5f   |   \" % (i, diff), end=\"\")\n",
-    "    print('   '.join(\"V(%s) = %.3f\" % (s, v)\n",
-    "                     for s, v in state_values.items()), end='\\n\\n')\n",
+    "    print('   '.join(\"V(%s) = %.3f\" % (s, v) for s, v in state_values.items()))\n",
     "    state_values = new_state_values\n",
     "\n",
     "    if diff < min_difference:\n",
@@ -573,9 +572,9 @@
    "source": [
     "print(\"Final state values:\", state_values)\n",
     "\n",
-    "assert abs(state_values['s0'] - 8.032) < 0.01\n",
-    "assert abs(state_values['s1'] - 11.169) < 0.01\n",
-    "assert abs(state_values['s2'] - 8.921) < 0.01"
+    "assert abs(state_values['s0'] - 3.781) < 0.01\n",
+    "assert abs(state_values['s1'] - 7.294) < 0.01\n",
+    "assert abs(state_values['s2'] - 4.202) < 0.01"
    ]
   },
   {
@@ -625,7 +624,7 @@
    "source": [
     "assert get_optimal_action(mdp, state_values, 's0', gamma) == 'a1'\n",
     "assert get_optimal_action(mdp, state_values, 's1', gamma) == 'a0'\n",
-    "assert get_optimal_action(mdp, state_values, 's2', gamma) == 'a0'"
+    "assert get_optimal_action(mdp, state_values, 's2', gamma) == 'a1'"
    ]
   },
   {
@@ -669,7 +668,7 @@
     "\n",
     "print(\"average reward: \", np.mean(rewards))\n",
     "\n",
-    "assert(0.85 < np.mean(rewards) < 1.0)"
+    "assert(0.40 < np.mean(rewards) < 0.55)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #242.

Also replaces `allclose` with a more semantically appropriate `isclose`.

Tested it and it works with my implementation of all `YOUR CODE HERE` blocks.