### PR TITLE
Replace image links from postimg.org to postimg.cc

### DIFF
--- a/week04_[recap]_deep_learning/practice_tensorflow.ipynb
+++ b/week04_[recap]_deep_learning/practice_tensorflow.ipynb
@@ -316,7 +316,7 @@
     "\n",
     "Here's what you should see:\n",
     "\n",
-    "<img src=\"https://s12.postimg.org/a374bmffx/tensorboard.png\" width=480>\n",
+    "<img src=\"https://s12.postimg.cc/a374bmffx/tensorboard.png\" width=480>\n",
     "\n",
     "Tensorboard also allows you to draw graphs (e.g. learning curves), record images & audio ~~and play flash games~~. This is useful when monitoring learning progress and catching some training issues.\n",
     "\n",

--- a/week04_approx_rl/homework_lasagne.ipynb
+++ b/week04_approx_rl/homework_lasagne.ipynb
@@ -206,7 +206,7 @@
     "# Building a DQN (2 pts)\n",
     "Here we define a simple agent that maps game images into Qvalues using simple convolutional neural network.\n",
     "\n",
-    "![scheme](https://s18.postimg.org/gbmsq6gmx/dqn_scheme.png)"
+    "![scheme](https://s18.postimg.cc/gbmsq6gmx/dqn_scheme.png)"
    ]
   },
   {

--- a/week08_pomdp/practice_tensorflow.ipynb
+++ b/week08_pomdp/practice_tensorflow.ipynb
@@ -466,7 +466,7 @@
     "### Training on parallel games\n",
     "\n",
     "We introduce a class called EnvPool - it's a tool that handles multiple environments for you. Here's how it works:\n",
-    "![img](https://s7.postimg.org/4y36s2b2z/env_pool.png)"
+    "![img](https://s7.postimg.cc/4y36s2b2z/env_pool.png)"
    ]
   },
   {

--- a/week09_policy_II/seminar_TRPO_pytorch.ipynb
+++ b/week09_policy_II/seminar_TRPO_pytorch.ipynb
@@ -731,7 +731,7 @@
     "\n",
     "In this section, you're invited to implement a better rollout strategy called _vine_.\n",
     "\n",
-    "![img](https://s17.postimg.org/i90chxgvj/vine.png)\n",
+    "![img](https://s17.postimg.cc/i90chxgvj/vine.png)\n",
     "\n",
     "In most gym environments, you can actually backtrack by using states. You can find a wrapper that saves/loads states in [the mcts seminar](https://github.com/yandexdataschool/Practical_RL/blob/master/week10_planning/seminar_MCTS.ipynb).\n",
     "\n",

--- a/week09_policy_II/seminar_TRPO_tensorflow.ipynb
+++ b/week09_policy_II/seminar_TRPO_tensorflow.ipynb
@@ -670,7 +670,7 @@
     "\n",
     "In this section, you're invited to implement a better rollout strategy called _vine_.\n",
     "\n",
-    "![img](https://s17.postimg.org/i90chxgvj/vine.png)\n",
+    "![img](https://s17.postimg.cc/i90chxgvj/vine.png)\n",
     "\n",
     "In most gym environments, you can actually backtrack by using states. You can find a wrapper that saves/loads states in [the mcts seminar](https://github.com/yandexdataschool/Practical_RL/blob/master/week10_planning/seminar_MCTS.ipynb).\n",
     "\n",

--- a/week09_policy_II/seminar_TRPO_theano.ipynb
+++ b/week09_policy_II/seminar_TRPO_theano.ipynb
@@ -674,7 +674,7 @@
     "\n",
     "In this section, you're invited to implement a better rollout strategy called _vine_.\n",
     "\n",
-    "![img](https://s17.postimg.org/i90chxgvj/vine.png)\n",
+    "![img](https://s17.postimg.cc/i90chxgvj/vine.png)\n",
     "\n",
     "In most gym environments, you can actually backtrack by using states. You can find a wrapper that saves/loads states in [the mcts seminar](https://github.com/yandexdataschool/Practical_RL/blob/master/week10_planning/seminar_MCTS.ipynb).\n",
     "\n",


### PR DESCRIPTION
Postimg has moved (see e.g. https://meta.stackexchange.com/questions/310325/should-we-fix-postimg-org-links-to-postimg-cc).