### PR TITLE
Replace %env magic with os.environ

### DIFF
--- a/week1_intro/crossentropy_method.ipynb
+++ b/week1_intro/crossentropy_method.ipynb
@@ -22,7 +22,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY = : 1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week1_intro/deep_crossentropy_method.ipynb
+++ b/week1_intro/deep_crossentropy_method.ipynb
@@ -25,7 +25,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY = : 1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week1_intro/gym_interface.ipynb
+++ b/week1_intro/gym_interface.ipynb
@@ -15,7 +15,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week3_model_free/experience_replay.ipynb
+++ b/week3_model_free/experience_replay.ipynb
@@ -41,7 +41,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week3_model_free/qlearning.ipynb
+++ b/week3_model_free/qlearning.ipynb
@@ -21,7 +21,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1\n",
+    "    os.environ['DISPLAY'] = ':1'\n",
     "        \n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/week3_model_free/sarsa.ipynb
+++ b/week3_model_free/sarsa.ipynb
@@ -21,7 +21,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1\n",
+    "    os.environ['DISPLAY'] = ':1'\n",
     "        \n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/week4_approx/dqn_atari.ipynb
+++ b/week4_approx/dqn_atari.ipynb
@@ -19,7 +19,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week4_approx/practice_approx_qlearning.ipynb
+++ b/week4_approx/practice_approx_qlearning.ipynb
@@ -26,7 +26,7 @@
     "import os\n",
     "if os.environ.get(\"DISPLAY\") is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week5_policy_based/practice_a3c.ipynb
+++ b/week5_policy_based/practice_a3c.ipynb
@@ -28,7 +28,7 @@
     "import os\n",
     "if os.environ.get(\"DISPLAY\") is str and len(os.environ.get(\"DISPLAY\"))!=0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week5_policy_based/practice_reinforce.ipynb
+++ b/week5_policy_based/practice_reinforce.ipynb
@@ -21,7 +21,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY = : 1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {

--- a/week6_outro/practice_mcts.ipynb
+++ b/week6_outro/practice_mcts.ipynb
@@ -16,7 +16,7 @@
     "import os\n",
     "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\"))==0:\n",
     "    !bash ../xvfb start\n",
-    "    %env DISPLAY=:1"
+    "    os.environ['DISPLAY'] = ':1'"
    ]
   },
   {


### PR DESCRIPTION
This ensures that future attempts to autoformat the code won't break it again.

Complementary to #283.