### PR TITLE
Change Taxi-v2 to Taxi-v3

### DIFF
--- a/week01_intro/crossentropy_method.ipynb
+++ b/week01_intro/crossentropy_method.ipynb
@@ -35,7 +35,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "env = gym.make(\"Taxi-v2\")\n",
+    "env = gym.make(\"Taxi-v3\")\n",
     "env.reset()\n",
     "env.render()"
    ]


### PR DESCRIPTION
Fix TaxiV2 env to TaxiV3.

New gym version will throw exception
`DeprecatedEnv: Env Taxi-v2 not found (valid versions include ['Taxi-v3'])`

> 2019-08-23 (v0.15.2)
> Taxi-v2 -> Taxi-v3 (add missing wall in the map to replicate env as describe in the original paper, thanks @kobotics) (https://github.com/openai/gym/blob/064a53ae65bbacf5f3ce1718e887b28ab84694d6/README.rst)