### PR TITLE
[week5] Fix accidental TimeLimit in CartPole

### DIFF
--- a/week5_policy_based/practice_reinforce.ipynb
+++ b/week5_policy_based/practice_reinforce.ipynb
@@ -59,15 +59,15 @@
    ],
    "source": [
     "import gym\n",
-    "import numpy as np, pandas as pd\n",
+    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
     "\n",
     "env = gym.make(\"CartPole-v0\")\n",
     "\n",
     "# gym compatibility: unwrap TimeLimit\n",
-    "if hasattr(env,'env'):\n",
-    "    env=env.env\n",
+    "if hasattr(env, '_max_episode_steps'):\n",
+    "    env = env.env\n",
     "\n",
     "env.reset()\n",
     "n_actions = env.action_space.n\n",
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_session(t_max=1000):\n",
+    "def generate_session(env, t_max=1000):\n",
     "    \"\"\"play env with REINFORCE agent and train at the session end\"\"\"\n",
     "\n",
     "    # arrays to record session\n",
@@ -339,7 +339,7 @@
     "\n",
     "for i in range(100):\n",
     "\n",
-    "    rewards = [generate_session() for _ in range(100)]  # generate new sessions\n",
+    "    rewards = [generate_session(env) for _ in range(100)]  # generate new sessions\n",
     "\n",
     "    print(\"mean reward:%.3f\" % (np.mean(rewards)))\n",
     "\n",
@@ -363,10 +363,9 @@
    "source": [
     "# record sessions\n",
     "import gym.wrappers\n",
-    "env = gym.wrappers.Monitor(gym.make(\"CartPole-v0\"),\n",
-    "                           directory=\"videos\", force=True)\n",
-    "sessions = [generate_session() for _ in range(100)]\n",
-    "env.close()"
+    "monitor_env = gym.wrappers.Monitor(gym.make(\"CartPole-v0\"), directory=\"videos\", force=True)\n",
+    "sessions = [generate_session(monitor_env) for _ in range(100)]\n",
+    "monitor_env.close()"
    ]
   },
   {

--- a/week5_policy_based/submit.py
+++ b/week5_policy_based/submit.py
@@ -1,11 +1,16 @@
 import sys
 import numpy as np
+import gym
 sys.path.append("..")
 import grading
 
 
 def submit_cartpole(generate_session, email, token):
-    sessions = [generate_session() for _ in range(100)]
+    env = gym.make("CartPole-v0")
+    if hasattr(env, '_max_episode_steps'):
+        env = env.env
+
+    sessions = [generate_session(env) for _ in range(100)]
     session_rewards = np.array(sessions)
     grader = grading.Grader("oyT3Bt7yEeeQvhJmhysb5g")
     grader.set_answer("7QKmA", int(np.mean(session_rewards)))


### PR DESCRIPTION
This is a fix for the bug reported in https://www.coursera.org/learn/practical-rl/discussions/all/threads/f1Q1d1RREemEwgpK0w-bBg/replies/C2ule8BMRPGrpXvATKTxOw/comments/GPDOqhjLTsCwzqoYyz7AjA .

Basically, the line

```
env = gym.wrappers.Monitor(gym.make("CartPole-v0"), directory="videos", force=True)
```

used to overwrite the `env` which was used in `generate_session()`, capping the time limit at 200.