### PR TITLE
Fix typos and logic errors in recap_ml.ipynb

### DIFF
--- a/week01_intro/primer_python_for_ml/recap_ml.ipynb
+++ b/week01_intro/primer_python_for_ml/recap_ml.ipynb
@@ -652,7 +652,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.iloc[5]"
+    "data.loc[5]"
    ]
   },
   {

--- a/week01_intro/primer_python_for_ml/recap_ml.ipynb
+++ b/week01_intro/primer_python_for_ml/recap_ml.ipynb
@@ -2469,22 +2469,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week01_intro/primer_python_for_ml/recap_ml.ipynb
+++ b/week01_intro/primer_python_for_ml/recap_ml.ipynb
@@ -42,7 +42,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "print(a * 2)"
    ]
@@ -70,8 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# run this first",
-    "\n",
+    "# run this first\n",
     "import math"
    ]
   },
@@ -81,12 +88,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# place your cursor at the end of the unfinished line below to find a function",
-    "\n",
-    "# that computes arctangent from two parameters (should have 2 in it's name)",
-    "\n",
-    "# once you chose it, press shift + tab + tab(again) to see the docs",
-    "\n",
+    "# place your cursor at the end of the unfinished line below to find a function\n",
+    "# that computes arctangent from two parameters (should have 2 in it's name)\n",
+    "# once you chose it, press shift + tab + tab(again) to see the docs\n",
     "\n",
     "math.a  # <---"
    ]
@@ -109,10 +113,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd",
-    "\n",
-    "# this yields a pandas.DataFrame",
-    "\n",
+    "import pandas as pd\n",
+    "# this yields a pandas.DataFrame\n",
     "data = pd.read_csv(\"train.csv\", index_col='PassengerId')"
    ]
   },
@@ -125,17 +127,17 @@
      "data": {
       "text/html": [
        "<div>\n",
-       "<style>\n",
-       "    .dataframe thead tr:only-child th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: left;\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -355,16 +357,14 @@
        "10               1      0            237736  30.0708   NaN        C  "
       ]
      },
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Selecting rows",
-    "\n",
-    "head = data[:10]",
-    "\n",
+    "# Selecting rows\n",
+    "head = data[:10]\n",
     "\n",
     "head  # if you leave an expression at the end of a cell, jupyter will \"display\" it automatically"
    ]
@@ -402,10 +402,8 @@
     }
    ],
    "source": [
-    "# table dimensions",
-    "\n",
-    "print(\"len(data) = \", len(data))",
-    "\n",
+    "# table dimensions\n",
+    "print(\"len(data) = \", len(data))\n",
     "print(\"data.shape = \", data.shape)"
    ]
   },
@@ -434,8 +432,7 @@
     }
    ],
    "source": [
-    "# select a single row",
-    "\n",
+    "# select a single row\n",
     "print(data.loc[4])"
    ]
   },
@@ -464,10 +461,8 @@
     }
    ],
    "source": [
-    "# select a single column.",
-    "\n",
-    "ages = data[\"Age\"]",
-    "\n",
+    "# select a single column.\n",
+    "ages = data[\"Age\"]\n",
     "print(ages[:10])  # alternatively: data.Age"
    ]
   },
@@ -480,17 +475,17 @@
      "data": {
       "text/html": [
        "<div>\n",
-       "<style>\n",
-       "    .dataframe thead tr:only-child th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: left;\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -552,16 +547,14 @@
        "10           30.0708       2"
       ]
      },
-     "execution_count": 6,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# select several columns and rows at once",
-    "\n",
-    "# alternatively: data[[\"Fare\",\"Pclass\"]].loc[5:10]",
-    "\n",
+    "# select several columns and rows at once\n",
+    "# alternatively: data[[\"Fare\",\"Pclass\"]].loc[5:10]\n",
     "data.loc[5:10, (\"Fare\", \"Pclass\")]"
    ]
   },
@@ -578,8 +571,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# select passengers number 13 and 666 - did they survive?",
-    "\n",
+    "# select passengers number 13 and 666 - did they survive?\n",
     "\n",
     "<YOUR CODE >"
    ]
@@ -590,8 +582,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compute the overall survival rate (what fraction of passengers survived the shipwreck)",
-    "\n",
+    "# compute the overall survival rate (what fraction of passengers survived the shipwreck)\n",
     "\n",
     "<YOUR CODE >"
    ]
@@ -670,8 +661,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data['Age'] = data['Age'].fillna(value=data['Age'].mean())",
-    "\n",
+    "data['Age'] = data['Age'].fillna(value=data['Age'].mean())\n",
     "data['Fare'] = data['Fare'].fillna(value=data['Fare'].mean())"
    ]
   },
@@ -725,30 +715,19 @@
     }
    ],
    "source": [
-    "import numpy as np",
+    "import numpy as np\n",
     "\n",
+    "a = np.array([1, 2, 3, 4, 5])\n",
+    "b = np.array([5, 4, 3, 2, 1])\n",
+    "print(\"a = \", a)\n",
+    "print(\"b = \", b)\n",
     "\n",
-    "a = np.array([1, 2, 3, 4, 5])",
-    "\n",
-    "b = np.array([5, 4, 3, 2, 1])",
-    "\n",
-    "print(\"a = \", a)",
-    "\n",
-    "print(\"b = \", b)",
-    "\n",
-    "\n",
-    "# math and boolean operations can applied to each element of an array",
-    "\n",
-    "print(\"a + 1 =\", a + 1)",
-    "\n",
-    "print(\"a * 2 =\", a * 2)",
-    "\n",
-    "print(\"a == 2\", a == 2)",
-    "\n",
-    "# ... or corresponding elements of two (or more) arrays",
-    "\n",
-    "print(\"a + b =\", a + b)",
-    "\n",
+    "# math and boolean operations can applied to each element of an array\n",
+    "print(\"a + 1 =\", a + 1)\n",
+    "print(\"a * 2 =\", a * 2)\n",
+    "print(\"a == 2\", a == 2)\n",
+    "# ... or corresponding elements of two (or more) arrays\n",
+    "print(\"a + b =\", a + b)\n",
     "print(\"a * b =\", a * b)"
    ]
   },
@@ -758,8 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Your turn: compute half-products of a and b elements (halves of products)",
-    "\n",
+    "# Your turn: compute half-products of a and b elements (halves of products)\n",
     "<YOUR CODE >"
    ]
   },
@@ -769,8 +747,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compute elementwise quotient between squared a and (b plus 1)",
-    "\n",
+    "# compute elementwise quotient between squared a and (b plus 1)\n",
     "<YOUR CODE >"
    ]
   },
@@ -821,33 +798,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time",
+    "%%time\n",
+    "# ^-- this \"magic\" measures and prints cell computation time\n",
     "\n",
-    "# ^-- this \"magic\" measures and prints cell computation time",
-    "\n",
-    "\n",
-    "# Option I: pure python",
-    "\n",
-    "arr_1 = range(1000000)",
-    "\n",
-    "arr_2 = range(99, 1000099)",
+    "# Option I: pure python\n",
+    "arr_1 = range(1000000)\n",
+    "arr_2 = range(99, 1000099)\n",
     "\n",
     "\n",
-    "\n",
-    "a_sum = []",
-    "\n",
-    "a_prod = []",
-    "\n",
-    "sqrt_a1 = []",
-    "\n",
-    "for i in range(len(arr_1)):",
-    "\n",
-    "    a_sum.append(arr_1[i]+arr_2[i])",
-    "\n",
-    "    a_prod.append(arr_1[i]*arr_2[i])",
-    "\n",
-    "    a_sum.append(arr_1[i]**0.5)",
-    "\n",
+    "a_sum = []\n",
+    "a_prod = []\n",
+    "sqrt_a1 = []\n",
+    "for i in range(len(arr_1)):\n",
+    "    a_sum.append(arr_1[i]+arr_2[i])\n",
+    "    a_prod.append(arr_1[i]*arr_2[i])\n",
+    "    a_sum.append(arr_1[i]**0.5)\n",
     "\n",
     "arr_1_sum = sum(arr_1)"
    ]
@@ -858,26 +823,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%% time",
+    "%%time\n",
+    "\n",
+    "# Option II: start from python, convert to numpy\n",
+    "arr_1 = range(1000000)\n",
+    "arr_2 = range(99, 1000099)\n",
+    "\n",
+    "arr_1, arr_2 = np.array(arr_1), np.array(arr_2)\n",
     "\n",
     "\n",
-    "# Option II: start from python, convert to numpy",
-    "\n",
-    "arr_1 = range(1000000)",
-    "\n",
-    "arr_2 = range(99, 1000099)",
-    "\n",
-    "\n",
-    "arr_1, arr_2 = np.array(arr_1), np.array(arr_2)",
-    "\n",
-    "\n",
-    "\n",
-    "a_sum = arr_1 + arr_2",
-    "\n",
-    "a_prod = arr_1 * arr_2",
-    "\n",
-    "sqrt_a1 = arr_1 ** .5",
-    "\n",
+    "a_sum = arr_1 + arr_2\n",
+    "a_prod = arr_1 * arr_2\n",
+    "sqrt_a1 = arr_1 ** .5\n",
     "arr_1_sum = arr_1.sum()"
    ]
   },
@@ -887,22 +844,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%% time",
+    "%%time\n",
     "\n",
+    "# Option III: pure numpy\n",
+    "arr_1 = np.arange(1000000)\n",
+    "arr_2 = np.arange(99, 1000099)\n",
     "\n",
-    "# Option III: pure numpy",
-    "\n",
-    "arr_1 = np.arange(1000000)",
-    "\n",
-    "arr_2 = np.arange(99, 1000099)",
-    "\n",
-    "\n",
-    "a_sum = arr_1 + arr_2",
-    "\n",
-    "a_prod = arr_1 * arr_2",
-    "\n",
-    "sqrt_a1 = arr_1 ** .5",
-    "\n",
+    "a_sum = arr_1 + arr_2\n",
+    "a_prod = arr_1 * arr_2\n",
+    "sqrt_a1 = arr_1 ** .5\n",
     "arr_1_sum = arr_1.sum()"
    ]
   },
@@ -968,26 +918,16 @@
     }
    ],
    "source": [
-    "a = np.array([1, 2, 3, 4, 5])",
-    "\n",
-    "b = np.array([5, 4, 3, 2, 1])",
-    "\n",
-    "print(\"numpy.sum(a) = \", np.sum(a))",
-    "\n",
-    "print(\"numpy.mean(a) = \", np.mean(a))",
-    "\n",
-    "print(\"numpy.min(a) = \",  np.min(a))",
-    "\n",
-    "print(\"numpy.argmin(b) = \", np.argmin(b))  # index of minimal element",
-    "\n",
-    "# dot product. Also used for matrix/tensor multiplication",
-    "\n",
-    "print(\"numpy.dot(a,b) = \", np.dot(a, b))",
-    "\n",
-    "print(\"numpy.unique(['male','male','female','female','male']) = \", np.unique(",
-    "\n",
-    "    ['male', 'male', 'female', 'female', 'male']))",
-    "\n",
+    "a = np.array([1, 2, 3, 4, 5])\n",
+    "b = np.array([5, 4, 3, 2, 1])\n",
+    "print(\"numpy.sum(a) = \", np.sum(a))\n",
+    "print(\"numpy.mean(a) = \", np.mean(a))\n",
+    "print(\"numpy.min(a) = \",  np.min(a))\n",
+    "print(\"numpy.argmin(b) = \", np.argmin(b))  # index of minimal element\n",
+    "# dot product. Also used for matrix/tensor multiplication\n",
+    "print(\"numpy.dot(a,b) = \", np.dot(a, b))\n",
+    "print(\"numpy.unique(['male','male','female','female','male']) = \", np.unique(\n",
+    "    ['male', 'male', 'female', 'female', 'male']))\n",
     "\n",
     "# and tons of other stuff. see http://bit.ly/2u5q430 ."
    ]
@@ -1027,9 +967,8 @@
     }
    ],
    "source": [
-    "print(\"Max ticket price: \", np.max(data[\"Fare\"]))",
-    "\n",
-    "print(\"\\nThe guy who paid the most:\\n\", data.loc[np.argmax(data[\"Fare\"])])"
+    "print(\"Max ticket price: \", np.max(data[\"Fare\"]))\n",
+    "print(\"\\nThe guy who paid the most:\\n\", data.iloc[np.argmax(data[\"Fare\"])])"
    ]
   },
   {
@@ -1038,8 +977,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# your code: compute mean passenger age and the oldest guy on the ship",
-    "\n",
+    "# your code: compute mean passenger age and the oldest guy on the ship\n",
     "<YOUR CODE >"
    ]
   },
@@ -1068,28 +1006,18 @@
     }
    ],
    "source": [
-    "print(\"Boolean operations\")",
+    "print(\"Boolean operations\")\n",
     "\n",
+    "print('a = ', a)\n",
+    "print('b = ', b)\n",
+    "print(\"a > 2\", a > 2)\n",
+    "print(\"numpy.logical_not(a>2) = \", np.logical_not(a > 2))\n",
+    "print(\"numpy.logical_and(a>2,b>2) = \", np.logical_and(a > 2, b > 2))\n",
+    "print(\"numpy.logical_or(a>4,b<3) = \", np.logical_or(a > 2, b < 3))\n",
     "\n",
-    "print('a = ', a)",
-    "\n",
-    "print('b = ', b)",
-    "\n",
-    "print(\"a > 2\", a > 2)",
-    "\n",
-    "print(\"numpy.logical_not(a>2) = \", np.logical_not(a > 2))",
-    "\n",
-    "print(\"numpy.logical_and(a>2,b>2) = \", np.logical_and(a > 2, b > 2))",
-    "\n",
-    "print(\"numpy.logical_or(a>4,b<3) = \", np.logical_or(a > 2, b < 3))",
-    "\n",
-    "\n",
-    "print(\"\\n shortcuts\")",
-    "\n",
-    "print(\"~(a > 2) = \", ~(a > 2))  # logical_not(a > 2)",
-    "\n",
-    "print(\"(a > 2) & (b > 2) = \", (a > 2) & (b > 2))  # logical_and",
-    "\n",
+    "print(\"\\n shortcuts\")\n",
+    "print(\"~(a > 2) = \", ~(a > 2))  # logical_not(a > 2)\n",
+    "print(\"(a > 2) & (b > 2) = \", (a > 2) & (b > 2))  # logical_and\n",
     "print(\"(a > 2) | (b < 3) = \", (a > 2) | (b < 3))  # logical_or"
    ]
   },
@@ -1112,12 +1040,12 @@
      "text": [
       "a =  [ 0  1  4  9 16 25]\n",
       "Select by element index\n",
-      "a[[1,2,5]] =  [1 4 25]\n",
+      "a[[1,2,5]] =  [ 1  4 25]\n",
       "\n",
       "Select by boolean mask\n",
       "a[a > 5] =  [ 9 16 25]\n",
       "(a % 2 == 0) = [ True False  True False  True False]\n",
-      "a[a > 3] = [ 0  4 16]\n",
+      "a[a % 2 == 0] = [ 0  4 16]\n",
       "data[(data['Age'] < 18) & (data['Sex'] == 'male')] = (below)\n"
      ]
     },
@@ -1125,17 +1053,17 @@
      "data": {
       "text/html": [
        "<div>\n",
-       "<style>\n",
-       "    .dataframe thead tr:only-child th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: left;\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -2171,39 +2099,27 @@
        "870              1      1             347742   11.1333      NaN        S  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "a = np.array([0, 1, 4, 9, 16, 25])",
+    "a = np.array([0, 1, 4, 9, 16, 25])\n",
+    "ix = np.array([1, 2, 5])\n",
+    "print(\"a = \", a)\n",
+    "print(\"Select by element index\")\n",
+    "print(\"a[[1,2,5]] = \", a[ix])\n",
     "\n",
-    "ix = np.array([1, 2, 5])",
-    "\n",
-    "print(\"a = \", a)",
-    "\n",
-    "print(\"Select by element index\")",
-    "\n",
-    "print(\"a[[1,2,5]] = \", a[ix])",
-    "\n",
-    "\n",
-    "print(\"\\nSelect by boolean mask\")",
-    "\n",
-    "# select all elementts in a that are greater than 5",
-    "\n",
-    "print(\"a[a > 5] = \", a[a > 5])",
-    "\n",
-    "print(\"(a % 2 == 0) =\", a % 2 == 0)  # True for even, False for odd",
-    "\n",
-    "print(\"a[a > 3] =\", a[a % 2 == 0])  # select all elements in a that are even",
+    "print(\"\\nSelect by boolean mask\")\n",
+    "# select all elementts in a that are greater than 5\n",
+    "print(\"a[a > 5] = \", a[a > 5])\n",
+    "print(\"(a % 2 == 0) =\", a % 2 == 0)  # True for even, False for odd\n",
+    "print(\"a[a % 2 == 0] =\", a[a % 2 == 0])  # select all elements in a that are even\n",
     "\n",
     "\n",
-    "\n",
-    "# select male children",
-    "\n",
-    "print(\"data[(data['Age'] < 18) & (data['Sex'] == 'male')] = (below)\")",
-    "\n",
+    "# select male children\n",
+    "print(\"data[(data['Age'] < 18) & (data['Sex'] == 'male')] = (below)\")\n",
     "data[(data['Age'] < 18) & (data['Sex'] == 'male')]"
    ]
   },
@@ -2222,13 +2138,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# who on average paid more for their ticket, men or women?",
+    "# who on average paid more for their ticket, men or women?\n",
     "\n",
-    "\n",
-    "mean_fare_men = <YOUR CODE >",
-    "\n",
-    "mean_fare_women = <YOUR CODE >",
-    "\n",
+    "mean_fare_men = <YOUR CODE >\n",
+    "mean_fare_women = <YOUR CODE >\n",
     "\n",
     "print(mean_fare_men, mean_fare_women)"
    ]
@@ -2239,13 +2152,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# who is more likely to survive: a child (<18 yo) or an adult?",
+    "# who is more likely to survive: a child (<18 yo) or an adult?\n",
     "\n",
-    "\n",
-    "child_survival_rate = <YOUR CODE >",
-    "\n",
-    "adult_survival_rate = <YOUR CODE >",
-    "\n",
+    "child_survival_rate = <YOUR CODE >\n",
+    "adult_survival_rate = <YOUR CODE >\n",
     "\n",
     "print(child_survival_rate, adult_survival_rate)"
    ]
@@ -2272,7 +2182,7 @@
        "[<matplotlib.lines.Line2D at 0x7f2fec9370f0>]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2288,15 +2198,11 @@
     }
    ],
    "source": [
-    "import matplotlib.pyplot as plt",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "# ^-- this \"magic\" tells all future matplotlib plots to be drawn inside notebook and not in a separate window.\n",
     "\n",
-    "%matplotlib inline",
-    "\n",
-    "# ^-- this \"magic\" tells all future matplotlib plots to be drawn inside notebook and not in a separate window.",
-    "\n",
-    "\n",
-    "# line plot",
-    "\n",
+    "# line plot\n",
     "plt.plot([0, 1, 2, 3, 4, 5], [0, 1, 4, 9, 16, 25])"
    ]
   },
@@ -2317,10 +2223,8 @@
     }
    ],
    "source": [
-    "# scatter-plot",
-    "\n",
-    "plt.scatter([0, 1, 2, 3, 4, 5], [0, 1, 4, 9, 16, 25])",
-    "\n",
+    "# scatter-plot\n",
+    "plt.scatter([0, 1, 2, 3, 4, 5], [0, 1, 4, 9, 16, 25])\n",
     "\n",
     "plt.show()  # show the first plot and begin drawing next one"
    ]
@@ -2336,7 +2240,7 @@
        "<matplotlib.text.Text at 0x7f2fe8fcaf28>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2352,26 +2256,17 @@
     }
    ],
    "source": [
-    "# draw a scatter plot with custom markers and colors",
+    "# draw a scatter plot with custom markers and colors\n",
+    "plt.scatter([1, 1, 2, 3, 4, 4.5], [3, 2, 2, 5, 15, 24],\n",
+    "            c=[\"red\", \"blue\", \"orange\", \"green\", \"cyan\", \"gray\"], marker=\"x\")\n",
     "\n",
-    "plt.scatter([1, 1, 2, 3, 4, 4.5], [3, 2, 2, 5, 15, 24],",
+    "# without .show(), several plots will be drawn on top of one another\n",
+    "plt.plot([0, 1, 2, 3, 4, 5], [0, 1, 4, 9, 16, 25], c=\"black\")\n",
     "\n",
-    "            c=[\"red\", \"blue\", \"orange\", \"green\", \"cyan\", \"gray\"], marker=\"x\")",
-    "\n",
-    "\n",
-    "# without .show(), several plots will be drawn on top of one another",
-    "\n",
-    "plt.plot([0, 1, 2, 3, 4, 5], [0, 1, 4, 9, 16, 25], c=\"black\")",
-    "\n",
-    "\n",
-    "# adding more sugar",
-    "\n",
-    "plt.title(\"Conspiracy theory proven!!!\")",
-    "\n",
-    "plt.xlabel(\"Per capita alcohol consumption\")",
-    "\n",
-    "plt.ylabel(\"# Layers in state of the art image classifier\")",
-    "\n",
+    "# adding more sugar\n",
+    "plt.title(\"Conspiracy theory proven!!!\")\n",
+    "plt.xlabel(\"Per capita alcohol consumption\")\n",
+    "plt.ylabel(\"# Layers in state of the art image classifier\")\n",
     "\n",
     "# fun with correlations: http://bit.ly/1FcNnWF"
    ]
@@ -2399,7 +2294,7 @@
        " <a list of 5 Patch objects>)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2415,15 +2310,11 @@
     }
    ],
    "source": [
-    "# histogram - showing data density",
+    "# histogram - showing data density\n",
+    "plt.hist([0, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 6, 7, 7, 8, 9, 10])\n",
+    "plt.show()\n",
     "\n",
-    "plt.hist([0, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 6, 7, 7, 8, 9, 10])",
-    "\n",
-    "plt.show()",
-    "\n",
-    "\n",
-    "plt.hist([0, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 4,",
-    "\n",
+    "plt.hist([0, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 4,\n",
     "          4, 5, 5, 5, 6, 7, 7, 8, 9, 10], bins=5)"
    ]
   },
@@ -2433,11 +2324,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot a histogram of age and a histogram of ticket fares on separate plots",
+    "# plot a histogram of age and a histogram of ticket fares on separate plots\n",
     "\n",
-    "\n",
-    "<YOUR CODE >",
-    "\n",
+    "<YOUR CODE >\n",
     "\n",
     "# bonus: use tab shift-tab to see if there is a way to draw a 2D histogram of age vs fare."
    ]
@@ -2448,11 +2337,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# make a scatter plot of passenger age vs ticket fare",
+    "# make a scatter plot of passenger age vs ticket fare\n",
     "\n",
-    "\n",
-    "<YOUR CODE >",
-    "\n",
+    "<YOUR CODE >\n",
     "\n",
     "# kudos if you add separate colors for men and women"
    ]
@@ -2498,23 +2385,16 @@
     }
    ],
    "source": [
-    "from sklearn.ensemble import RandomForestClassifier",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import accuracy_score\n",
     "\n",
-    "from sklearn.metrics import accuracy_score",
+    "features = data[[\"Fare\", \"SibSp\"]].copy()\n",
+    "answers = data[\"Survived\"]\n",
     "\n",
+    "model = RandomForestClassifier(n_estimators=100)\n",
+    "model.fit(features[:-100], answers[:-100])\n",
     "\n",
-    "features = data[[\"Fare\", \"SibSp\"]].copy()",
-    "\n",
-    "answers = data[\"Survived\"]",
-    "\n",
-    "\n",
-    "model = RandomForestClassifier(n_estimators=100)",
-    "\n",
-    "model.fit(features[:-100], answers[:-100])",
-    "\n",
-    "\n",
-    "test_predictions = model.predict(features[-100:])",
-    "\n",
+    "test_predictions = model.predict(features[-100:])\n",
     "print(\"Test accuracy:\", accuracy_score(answers[-100:], test_predictions))"
    ]
   },
@@ -2589,9 +2469,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/week01_intro/primer_python_for_ml/recap_ml.ipynb
+++ b/week01_intro/primer_python_for_ml/recap_ml.ipynb
@@ -641,7 +641,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some columns contain __NaN__ values - this means that there is no data there. For example, passenger `#5` has unknown age. To simplify the future data analysis, we'll replace NaN values by using pandas `fillna` function.\n",
+    "Some columns contain __NaN__ values - this means that there is no data there. For example, passenger `#6` has unknown age. To simplify the future data analysis, we'll replace NaN values by using pandas `fillna` function.\n",
     "\n",
     "_Note: we do this so easily because it's a tutorial. In general, you think twice before you modify data like this._"
    ]
@@ -652,7 +652,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.loc[5]"
+    "data.loc[6]"
    ]
   },
   {
@@ -671,7 +671,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.iloc[5]"
+    "data.loc[6]"
    ]
   },
   {


### PR DESCRIPTION
The following typos were fixed:

1. In Part III, there were spaces between `%%` and `time` in the second and third examples of using `%%time`. Those spaces were removed.
2. In Part III, in the example of selecting all elements in a that are even, an incorrect string was being printed.

The following logic error was fixed:
1. In Part III, in the example that found the person who paid the most `data.loc` was incorrectly being used instead of `data.iloc`.