### PR TITLE
Add NumpySummaries class

### DIFF
--- a/week06_policy_based/a2c-optional.ipynb
+++ b/week06_policy_based/a2c-optional.ipynb
@@ -52,10 +52,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from atari_wrappers import nature_dqn_env\n",
+    "from atari_wrappers import nature_dqn_env, NumpySummaries\n",
     "\n",
     "\n",
-    "env = nature_dqn_env(\"SpaceInvadersNoFrameskip-v4\", nenvs=8)\n",
+    "env = nature_dqn_env(\"SpaceInvadersNoFrameskip-v4\", nenvs=8, summaries = 'Numpy')\n",
     "obs = env.reset()\n",
     "assert obs.shape == (8, 84, 84, 4)\n",
     "assert obs.dtype == np.uint8"


### PR DESCRIPTION
Previously only TFSummaries was supported.

Those who wanted to use Pytorch, had to implement summaries method by
themselves (to get total reward).

Now NumpySummaries class is added. It allows to get summaries without
tensorflow.

In the notebook it's set to default now.