### PR TITLE
[Week 6] Avoid AttributeError on TF BasicTranslationModel

### DIFF
--- a/week6_outro/seq2seq/practice_tf.ipynb
+++ b/week6_outro/seq2seq/practice_tf.ipynb
@@ -760,15 +760,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.translate(\"EXAMPLE;\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
As reported in https://www.coursera.org/learn/practical-rl/discussions/all/threads/4F_UVY3bTGif1FWN25xodg, `model.translate()` does not exist. The corresponding cell was removed in the PyTorch version of the notebook, so I am also removing it here.