### PR TITLE
Cleanup JSON in notebooks

### DIFF
--- a/week01_intro/crossentropy_method.ipynb
+++ b/week01_intro/crossentropy_method.ipynb
@@ -405,22 +405,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week02_value_based/seminar_vi.ipynb
+++ b/week02_value_based/seminar_vi.ipynb
@@ -1215,22 +1215,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week03_model_free/homework.ipynb
+++ b/week03_model_free/homework.ipynb
@@ -715,35 +715,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week03_model_free/seminar_qlearning.ipynb
+++ b/week03_model_free/seminar_qlearning.ipynb
@@ -425,35 +425,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week04_[recap]_deep_learning/practice_tensorflow.ipynb
+++ b/week04_[recap]_deep_learning/practice_tensorflow.ipynb
@@ -57,7 +57,7 @@
        "662921401752298880"
       ]
      },
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,7 +527,7 @@
        "<matplotlib.legend.Legend at 0x7f8e8d16c510>"
       ]
      },
-     "execution_count": 50,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -604,7 +604,7 @@
        "<matplotlib.legend.Legend at 0x7f8e84b43f90>"
       ]
      },
-     "execution_count": 69,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/week04_[recap]_deep_learning/seminar_pytorch.ipynb
+++ b/week04_[recap]_deep_learning/seminar_pytorch.ipynb
@@ -284,7 +284,7 @@
        "<matplotlib.collections.PathCollection at 0x7fb9a5c1d898>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -611,7 +611,7 @@
        "tensor([ 0.4526,  0.4411,  0.5917])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/week04_approx_rl/homework_pytorch_debug.ipynb
+++ b/week04_approx_rl/homework_pytorch_debug.ipynb
@@ -1,999 +1,821 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "homework_pytorch_debug.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.8"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deep Q-Network implementation.\n",
+    "\n",
+    "This homework shamelessly demands you to implement a DQN - an approximate q-learning algorithm with experience replay and target networks - and see if it works any better this way.\n",
+    "\n",
+    "Original paper:\n",
+    "https://arxiv.org/pdf/1312.5602.pdf"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**This notebook is given for debug.** The main task is in the other notebook (**homework_pytorch_main**). The tasks are similar and share most of the code. The main difference is in environments. In main notebook it can take some 2 hours for the agent to start improving so it seems reasonable to launch the algorithm on a simpler env first. Here it is CartPole and it will train in several minutes.\n",
+    "\n",
+    "**We suggest the following pipeline:** First implement debug notebook then implement the main one.\n",
+    "\n",
+    "**About evaluation:** All points are given for the main notebook with one exception: if agent fails to beat the threshold in main notebook you can get 1 pt (instead of 3 pts) for beating the threshold in debug notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "XE4Jsneirwp8"
-      },
-      "source": [
-        "# Deep Q-Network implementation.\n",
-        "\n",
-        "This homework shamelessly demands you to implement a DQN - an approximate q-learning algorithm with experience replay and target networks - and see if it works any better this way.\n",
-        "\n",
-        "Original paper:\n",
-        "https://arxiv.org/pdf/1312.5602.pdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "bJ5LraFdrwqC"
-      },
-      "source": [
-        "**This notebook is given for debug.** The main task is in the other notebook (**homework_pytorch_main**). The tasks are similar and share most of the code. The main difference is in environments. In main notebook it can take some 2 hours for the agent to start improving so it seems reasonable to launch the algorithm on a simpler env first. Here it is CartPole and it will train in several minutes.\n",
-        "\n",
-        "**We suggest the following pipeline:** First implement debug notebook then implement the main one.\n",
-        "\n",
-        "**About evaluation:** All points are given for the main notebook with one exception: if agent fails to beat the threshold in main notebook you can get 1 pt (instead of 3 pts) for beating the threshold in debug notebook."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "dQDR7sPZrwqF",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "outputId": "927ce582-94c9-454e-d205-16c0e2f05910"
-      },
-      "source": [
-        "# in google colab uncomment this\n",
-        "\n",
-        "import os\n",
-        "\n",
-        "os.system('apt-get update')\n",
-        "os.system('apt-get install -y xvfb')\n",
-        "os.system('wget https://raw.githubusercontent.com/yandexdataschool/Practical_DL/fall18/xvfb -O ../xvfb')\n",
-        "os.system('apt-get install -y python-opengl ffmpeg')\n",
-        "os.system('pip install pyglet==1.5.0')\n",
-        "\n",
-        "os.system('python -m pip install -U pygame --user')\n",
-        "os.system('pip install gym[box2d]')\n",
-        "\n",
-        "prefix = 'https://raw.githubusercontent.com/yandexdataschool/Practical_RL/master/week04_approx_rl/'\n",
-        "\n",
-        "os.system('wget ' + prefix + 'atari_wrappers.py')\n",
-        "os.system('wget ' + prefix + 'utils.py')\n",
-        "os.system('wget ' + prefix + 'replay_buffer.py')\n",
-        "os.system('wget ' + prefix + 'framebuffer.py')\n",
-        "\n",
-        "print('setup complete')\n",
-        "\n",
-        "# XVFB will be launched if you run on a server\n",
-        "import os\n",
-        "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
-        "    !bash ../xvfb start\n",
-        "    os.environ['DISPLAY'] = ':1'"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "setup complete\n",
-            "Starting virtual X frame buffer: Xvfb.\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Jqjk0iAHrwqN"
-      },
-      "source": [
-        "__Frameworks__ - we'll accept this homework in any deep learning framework. This particular notebook was designed for pytoch, but you find it easy to adapt it to almost any python-based deep learning framework."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "XGvLBKVwrwqP",
-        "colab": {}
-      },
-      "source": [
-        "import random\n",
-        "import numpy as np\n",
-        "import torch\n",
-        "import utils"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "CKt9yo9grwqV",
-        "colab": {}
-      },
-      "source": [
-        "import gym\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ppQ08-61rwqb"
-      },
-      "source": [
-        "### CartPole again\n",
-        "\n",
-        "Another env can be used without any modification of the code. State space should be a single vector, actions should be discrete.\n",
-        "\n",
-        "CartPole is the simplest one. It should take several minutes to solve it.\n",
-        "\n",
-        "For LunarLander it can take 1-2 hours to get 200 points (a good score) on Colab and training progress does not look informative."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "7Zhe6Et3rwqd",
-        "colab": {}
-      },
-      "source": [
-        "ENV_NAME = 'CartPole-v1'\n",
-        "\n",
-        "def make_env(seed=None):\n",
-        "    # some envs are wrapped with a time limit wrapper by default\n",
-        "    env = gym.make(ENV_NAME).unwrapped\n",
-        "    if seed is not None:\n",
-        "        env.seed(seed)\n",
-        "    return env"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "BKg_pIiNrwqh",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 303
-        },
-        "outputId": "add22976-97e6-4eee-bf96-d437750a35d9"
-      },
-      "source": [
-        "env = make_env()\n",
-        "env.reset()\n",
-        "plt.imshow(env.render(\"rgb_array\"))\n",
-        "state_shape, n_actions = env.observation_space.shape, env.action_space.n"
-      ],
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.6/dist-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
-            "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARSUlEQVR4nO3df6zddX3H8edLQHRqBsi16fpjRe1i\ncJnF3SFG/0CMCsSsmjgDW6QxJJclmGBitoFLpiYj0WTKZuaINTDr4kTmj9AQNsVKYvxDsMVaWxC5\nagltKi0KqDFjK773x/0Uz+ot99wfh9vPPc9HcnK+3/f38z3n/YmHl99++j09qSokSf14znI3IEma\nH4NbkjpjcEtSZwxuSeqMwS1JnTG4JakzIwvuJBcneSDJdJJrR/U+kjRuMor7uJOcAvwAeBNwAPg2\ncHlV3bfkbyZJY2ZUV9znA9NV9aOq+h/gFmDziN5LksbKqSN63TXAwwP7B4DXnGjw2WefXRs2bBhR\nK5LUn/379/Poo49mtmOjCu45JZkCpgDWr1/Pzp07l6sVSTrpTE5OnvDYqJZKDgLrBvbXttrTqmpr\nVU1W1eTExMSI2pCklWdUwf1tYGOSc5I8F7gM2D6i95KksTKSpZKqOprkPcBXgFOAm6tq3yjeS5LG\nzcjWuKvqDuCOUb2+JI0rvzkpSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmd\nMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4Jakzi/rpsiT7gV8ATwFHq2oy\nyVnA54ENwH7gnVX12OLalCQdsxRX3G+oqk1VNdn2rwV2VNVGYEfblyQtkVEslWwGtrXtbcDbRvAe\nkjS2FhvcBXw1ya4kU622qqoOte2fAKsW+R6SpAGLWuMGXl9VB5O8BLgzyfcHD1ZVJanZTmxBPwWw\nfv36RbYhSeNjUVfcVXWwPR8GvgycDzySZDVAez58gnO3VtVkVU1OTEwspg1JGisLDu4kL0jyomPb\nwJuBvcB2YEsbtgW4bbFNSpJ+YzFLJauALyc59jr/XlX/leTbwK1JrgQeAt65+DYlSccsOLir6kfA\nq2ap/xR442KakiSdmN+clKTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4Jakzhjc\nktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjozZ3AnuTnJ4SR7B2pn\nJbkzyYPt+cxWT5KPJ5lOsifJq0fZvCSNo2GuuD8NXHxc7VpgR1VtBHa0fYBLgI3tMQXcuDRtSpKO\nmTO4q+obwM+OK28GtrXtbcDbBuqfqRnfAs5IsnqpmpUkLXyNe1VVHWrbPwFWte01wMMD4w602m9J\nMpVkZ5KdR44cWWAbkjR+Fv2Xk1VVQC3gvK1VNVlVkxMTE4ttQ5LGxkKD+5FjSyDt+XCrHwTWDYxb\n22qSpCWy0ODeDmxp21uA2wbqV7S7Sy4AnhhYUpEkLYFT5xqQ5HPAhcDZSQ4AHwA+DNya5ErgIeCd\nbfgdwKXANPAr4N0j6FmSxtqcwV1Vl5/g0BtnGVvA1YttSpJ0Yn5zUpI6Y3BLUmcMbknqjMEtSZ0x\nuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNb\nkjpjcEtSZ+YM7iQ3JzmcZO9A7YNJDibZ3R6XDhy7Lsl0kgeSvGVUjUvSuBrmivvTwMWz1G+oqk3t\ncQdAknOBy4BXtnP+JckpS9WsJGmI4K6qbwA/G/L1NgO3VNWTVfVjZn7t/fxF9CdJOs5i1rjfk2RP\nW0o5s9XWAA8PjDnQar8lyVSSnUl2HjlyZBFtSNJ4WWhw3wi8DNgEHAI+Ot8XqKqtVTVZVZMTExML\nbEOSxs+CgruqHqmqp6rq18Cn+M1yyEFg3cDQta0mSVoiCwruJKsHdt8OHLvjZDtwWZLTk5wDbATu\nWVyLkqRBp841IMnngAuBs5McAD4AXJhkE1DAfuAqgKral+RW4D7gKHB1VT01mtYlaTzNGdxVdfks\n5ZueYfz1wPWLaUqSdGJ+c1KSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1Zs7bAaWVbNfWq2at//HU\nJ5/lTqThecUtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1\nZs7gTrIuyV1J7kuyL8k1rX5WkjuTPNiez2z1JPl4kukke5K8etSTkKRxMswV91HgfVV1LnABcHWS\nc4FrgR1VtRHY0fYBLmHm1903AlPAjUvetSSNsTmDu6oOVdW9bfsXwP3AGmAzsK0N2wa8rW1vBj5T\nM74FnJFk9ZJ3Lkljal5r3Ek2AOcBdwOrqupQO/QTYFXbXgM8PHDagVY7/rWmkuxMsvPIkSPzbFuS\nxtfQwZ3khcAXgfdW1c8Hj1VVATWfN66qrVU1WVWTExMT8zlVksbaUMGd5DRmQvuzVfWlVn7k2BJI\nez7c6geBdQOnr201SdISGOaukgA3AfdX1ccGDm0HtrTtLcBtA/Ur2t0lFwBPDCypSJIWaZifLnsd\n8C7ge0l2t9r7gQ8Dtya5EngIeGc7dgdwKTAN/Ap495J2LEljbs7grqpvAjnB4TfOMr6AqxfZlyTp\nBPzmpHQcfyhYJzuDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1Jn\nDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjozzI8Fr0tyV5L7kuxLck2rfzDJwSS72+PS\ngXOuSzKd5IEkbxnlBCRp3AzzY8FHgfdV1b1JXgTsSnJnO3ZDVf3D4OAk5wKXAa8Efg/4WpI/qKqn\nlrJxSRpXc15xV9Whqrq3bf8CuB9Y8wynbAZuqaonq+rHzPza+/lL0awkaZ5r3Ek2AOcBd7fSe5Ls\nSXJzkjNbbQ3w8MBpB3jmoJeWxa6tV/1WzR8KVg+GDu4kLwS+CLy3qn4O3Ai8DNgEHAI+Op83TjKV\nZGeSnUeOHJnPqZI01oYK7iSnMRPan62qLwFU1SNV9VRV/Rr4FL9ZDjkIrBs4fW2r/T9VtbWqJqtq\ncmJiYjFzkKSxMsxdJQFuAu6vqo8N1FcPDHs7sLdtbwcuS3J6knOAjcA9S9eyJI23Ye4qeR3wLuB7\nSXa32vuBy5NsAgrYD1wFUFX7ktwK3MfMHSlXe0eJJC2dOYO7qr4JZJZDdzzDOdcD1y+iL0nSCfjN\nSUnqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCW\npM4Y3FpRkgz9GMX50rPB4JakzgzzQwrSinX7oamnt9+6eusydiINzytuja3B0J5tXzpZGdyS1Jlh\nfiz4eUnuSfLdJPuSfKjVz0lyd5LpJJ9P8txWP73tT7fjG0Y7BUkaL8NccT8JXFRVrwI2ARcnuQD4\nCHBDVb0ceAy4so2/Enis1W9o46STzvFr2q5xqxfD/FhwAb9su6e1RwEXAX/e6tuADwI3ApvbNsAX\ngH9OkvY60klj8qqtwG/C+oPL1ok0P0PdVZLkFGAX8HLgE8APgcer6mgbcgBY07bXAA8DVNXRJE8A\nLwYePdHr79q1y/ti1R0/s1ouQwV3VT0FbEpyBvBl4BWLfeMkU8AUwPr163nooYcW+5LSsxqm/iFS\nozQ5OXnCY/O6q6SqHgfuAl4LnJHkWPCvBQ627YPAOoB2/HeBn87yWlurarKqJicmJubThiSNtWHu\nKploV9okeT7wJuB+ZgL8HW3YFuC2tr297dOOf931bUlaOsMslawGtrV17ucAt1bV7UnuA25J8vfA\nd4Cb2vibgH9LMg38DLhsBH1L0tga5q6SPcB5s9R/BJw/S/2/gT9bku4kSb/Fb05KUmcMbknqjMEt\nSZ3xn3XViuINTBoHXnFLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J\n6ozBLUmdMbglqTMGtyR1xuCWpM4M82PBz0tyT5LvJtmX5EOt/ukkP06yuz02tXqSfDzJdJI9SV49\n6klI0jgZ5t/jfhK4qKp+meQ04JtJ/rMd+6uq+sJx4y8BNrbHa4Ab27MkaQnMecVdM37Zdk9rj2f6\n1+o3A59p530LOCPJ6sW3KkmCIde4k5ySZDdwGLizqu5uh65vyyE3JDm91dYADw+cfqDVJElLYKjg\nrqqnqmoTsBY4P8kfAtcBrwD+BDgL+Jv5vHGSqSQ7k+w8cuTIPNuWpPE1r7tKqupx4C7g4qo61JZD\nngT+FTi/DTsIrBs4bW2rHf9aW6tqsqomJyYmFta9JI2hYe4qmUhyRtt+PvAm4PvH1q2TBHgbsLed\nsh24ot1dcgHwRFUdGkn3kjSGhrmrZDWwLckpzAT9rVV1e5KvJ5kAAuwG/rKNvwO4FJgGfgW8e+nb\nlqTxNWdwV9Ue4LxZ6hedYHwBVy++NUnSbPzmpCR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1J\nnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZ\ng1uSOmNwS1JnDG5J6kyqarl7IMkvgAeWu48RORt4dLmbGIGVOi9YuXNzXn35/aqamO3Aqc92Jyfw\nQFVNLncTo5Bk50qc20qdF6zcuTmvlcOlEknqjMEtSZ05WYJ763I3MEIrdW4rdV6wcufmvFaIk+Iv\nJyVJwztZrrglSUNa9uBOcnGSB5JMJ7l2ufuZryQ3JzmcZO9A7awkdyZ5sD2f2epJ8vE21z1JXr18\nnT+zJOuS3JXkviT7klzT6l3PLcnzktyT5LttXh9q9XOS3N36/3yS57b66W1/uh3fsJz9zyXJKUm+\nk+T2tr9S5rU/yfeS7E6ys9W6/iwuxrIGd5JTgE8AlwDnApcnOXc5e1qATwMXH1e7FthRVRuBHW0f\nZua5sT2mgBufpR4X4ijwvqo6F7gAuLr9b9P73J4ELqqqVwGbgIuTXAB8BLihql4OPAZc2cZfCTzW\n6je0cSeza4D7B/ZXyrwA3lBVmwZu/ev9s7hwVbVsD+C1wFcG9q8DrlvOnhY4jw3A3oH9B4DVbXs1\nM/epA3wSuHy2cSf7A7gNeNNKmhvwO8C9wGuY+QLHqa3+9OcS+Arw2rZ9ahuX5e79BPNZy0yAXQTc\nDmQlzKv1uB84+7jaivkszvex3Esla4CHB/YPtFrvVlXVobb9E2BV2+5yvu2P0ecBd7MC5taWE3YD\nh4E7gR8Cj1fV0TZksPen59WOPwG8+NnteGj/CPw18Ou2/2JWxrwACvhqkl1Jplqt+8/iQp0s35xc\nsaqqknR7606SFwJfBN5bVT9P8vSxXudWVU8Bm5KcAXwZeMUyt7RoSd4KHK6qXUkuXO5+RuD1VXUw\nyUuAO5N8f/Bgr5/FhVruK+6DwLqB/bWt1rtHkqwGaM+HW72r+SY5jZnQ/mxVfamVV8TcAKrqceAu\nZpYQzkhy7EJmsPen59WO/y7w02e51WG8DvjTJPuBW5hZLvkn+p8XAFV1sD0fZub/bM9nBX0W52u5\ng/vbwMb2N9/PBS4Dti9zT0thO7ClbW9hZn34WP2K9rfeFwBPDPxR76SSmUvrm4D7q+pjA4e6nluS\niXalTZLnM7Nufz8zAf6ONuz4eR2b7zuAr1dbOD2ZVNV1VbW2qjYw89/R16vqL+h8XgBJXpDkRce2\ngTcDe+n8s7goy73IDlwK/ICZdca/Xe5+FtD/54BDwP8ys5Z2JTNrhTuAB4GvAWe1sWHmLpofAt8D\nJpe7/2eY1+uZWVfcA+xuj0t7nxvwR8B32rz2An/X6i8F7gGmgf8ATm/157X96Xb8pcs9hyHmeCFw\n+0qZV5vDd9tj37Gc6P2zuJiH35yUpM4s91KJJGmeDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLU\nGYNbkjrzf0Ew7Is+EjUWAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "n1NkkZbcrwqn"
-      },
-      "source": [
-        "### Building a network"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "xbntvEn9rwqq"
-      },
-      "source": [
-        "We now need to build a neural network that can map observations to state q-values.\n",
-        "The model does not have to be huge yet. 1-2 hidden layers with < 200 neurons and ReLU activation will probably be enough. Batch normalization and dropout can spoil everything here."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "pBeABllTrwqr",
-        "colab": {}
-      },
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-        "# those who have a GPU but feel unfair to use it can uncomment:\n",
-        "# device = torch.device('cpu')\n",
-        "device"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "JcUmtE3jrwqw",
-        "colab": {}
-      },
-      "source": [
-        "class DQNAgent(nn.Module):\n",
-        "    def __init__(self, state_shape, n_actions, epsilon=0):\n",
-        "\n",
-        "        super().__init__()\n",
-        "        self.epsilon = epsilon\n",
-        "        self.n_actions = n_actions\n",
-        "        self.state_shape = state_shape\n",
-        "        # Define your network body here. Please make sure agent is fully contained here\n",
-        "        assert len(state_shape) == 1\n",
-        "        state_dim = state_shape[0]\n",
-        "        <YOUR CODE>\n",
-        "\n",
-        "        \n",
-        "    def forward(self, state_t):\n",
-        "        \"\"\"\n",
-        "        takes agent's observation (tensor), returns qvalues (tensor)\n",
-        "        :param state_t: a batch states, shape = [batch_size, *state_dim=4]\n",
-        "        \"\"\"\n",
-        "        # Use your network to compute qvalues for given state\n",
-        "        qvalues = <YOUR CODE>\n",
-        "\n",
-        "        assert qvalues.requires_grad, \"qvalues must be a torch tensor with grad\"\n",
-        "        assert len(\n",
-        "            qvalues.shape) == 2 and qvalues.shape[0] == state_t.shape[0] and qvalues.shape[1] == n_actions\n",
-        "\n",
-        "        return qvalues\n",
-        "\n",
-        "    def get_qvalues(self, states):\n",
-        "        \"\"\"\n",
-        "        like forward, but works on numpy arrays, not tensors\n",
-        "        \"\"\"\n",
-        "        model_device = next(self.parameters()).device\n",
-        "        states = torch.tensor(states, device=model_device, dtype=torch.float32)\n",
-        "        qvalues = self.forward(states)\n",
-        "        return qvalues.data.cpu().numpy()\n",
-        "\n",
-        "    def sample_actions(self, qvalues):\n",
-        "        \"\"\"pick actions given qvalues. Uses epsilon-greedy exploration strategy. \"\"\"\n",
-        "        epsilon = self.epsilon\n",
-        "        batch_size, n_actions = qvalues.shape\n",
-        "\n",
-        "        random_actions = np.random.choice(n_actions, size=batch_size)\n",
-        "        best_actions = qvalues.argmax(axis=-1)\n",
-        "\n",
-        "        should_explore = np.random.choice(\n",
-        "            [0, 1], batch_size, p=[1-epsilon, epsilon])\n",
-        "        return np.where(should_explore, random_actions, best_actions)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "cJ3Z0MF4rwq0",
-        "colab": {}
-      },
-      "source": [
-        "agent = DQNAgent(state_shape, n_actions, epsilon=0.5).to(device)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "wqiBCetxrwq5"
-      },
-      "source": [
-        "Now let's try out our agent to see if it raises any errors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "l28BqJYWrwq7",
-        "colab": {}
-      },
-      "source": [
-        "def evaluate(env, agent, n_games=1, greedy=False, t_max=10000):\n",
-        "    \"\"\" Plays n_games full games. If greedy, picks actions as argmax(qvalues). Returns mean reward. \"\"\"\n",
-        "    rewards = []\n",
-        "    for _ in range(n_games):\n",
-        "        s = env.reset()\n",
-        "        reward = 0\n",
-        "        for _ in range(t_max):\n",
-        "            qvalues = agent.get_qvalues([s])\n",
-        "            action = qvalues.argmax(axis=-1)[0] if greedy else agent.sample_actions(qvalues)[0]\n",
-        "            s, r, done, _ = env.step(action)\n",
-        "            reward += r\n",
-        "            if done:\n",
-        "                break\n",
-        "\n",
-        "        rewards.append(reward)\n",
-        "    return np.mean(rewards)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ASyilgjbrwq-",
-        "colab": {}
-      },
-      "source": [
-        "evaluate(env, agent, n_games=1)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "c0LHCCO_rwrC"
-      },
-      "source": [
-        "### Experience replay\n",
-        "For this assignment, we provide you with experience replay buffer. If you implemented experience replay buffer in last week's assignment, you can copy-paste it here in main notebook **to get 2 bonus points**.\n",
-        "\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/exp_replay.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "i0su2ZnNrwrD"
-      },
-      "source": [
-        "#### The interface is fairly simple:\n",
-        "* `exp_replay.add(obs, act, rw, next_obs, done)` - saves (s,a,r,s',done) tuple into the buffer\n",
-        "* `exp_replay.sample(batch_size)` - returns observations, actions, rewards, next_observations and is_done for `batch_size` random samples.\n",
-        "* `len(exp_replay)` - returns number of elements stored in replay buffer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "6c_oU7HTrwrF",
-        "colab": {}
-      },
-      "source": [
-        "from replay_buffer import ReplayBuffer\n",
-        "exp_replay = ReplayBuffer(10)\n",
-        "\n",
-        "for _ in range(30):\n",
-        "    exp_replay.add(env.reset(), env.action_space.sample(),\n",
-        "                   1.0, env.reset(), done=False)\n",
-        "\n",
-        "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "    5)\n",
-        "\n",
-        "assert len(exp_replay) == 10, \"experience replay size should be 10 because that's what maximum capacity is\""
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "1SNYsOWnrwrI",
-        "colab": {}
-      },
-      "source": [
-        "def play_and_record(initial_state, agent, env, exp_replay, n_steps=1):\n",
-        "    \"\"\"\n",
-        "    Play the game for exactly n steps, record every (s,a,r,s', done) to replay buffer. \n",
-        "    Whenever game ends, add record with done=True and reset the game.\n",
-        "    It is guaranteed that env has done=False when passed to this function.\n",
-        "\n",
-        "    PLEASE DO NOT RESET ENV UNLESS IT IS \"DONE\"\n",
-        "\n",
-        "    :returns: return sum of rewards over time and the state in which the env stays\n",
-        "    \"\"\"\n",
-        "    s = initial_state\n",
-        "    sum_rewards = 0\n",
-        "\n",
-        "    # Play the game for n_steps as per instructions above\n",
-        "    <YOUR CODE >\n",
-        "\n",
-        "    return sum_rewards, s"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "xgQ2sqA5rwrN",
-        "colab": {}
-      },
-      "source": [
-        "# testing your code.\n",
-        "exp_replay = ReplayBuffer(2000)\n",
-        "\n",
-        "state = env.reset()\n",
-        "play_and_record(state, agent, env, exp_replay, n_steps=1000)\n",
-        "\n",
-        "# if you're using your own experience replay buffer, some of those tests may need correction.\n",
-        "# just make sure you know what your code does\n",
-        "assert len(exp_replay) == 1000, \"play_and_record should have added exactly 1000 steps, \"\\\n",
-        "                                 \"but instead added %i\" % len(exp_replay)\n",
-        "is_dones = list(zip(*exp_replay._storage))[-1]\n",
-        "\n",
-        "assert 0 < np.mean(is_dones) < 0.1, \"Please make sure you restart the game whenever it is 'done' and record the is_done correctly into the buffer.\"\\\n",
-        "                                    \"Got %f is_done rate over %i steps. [If you think it's your tough luck, just re-run the test]\" % (\n",
-        "                                        np.mean(is_dones), len(exp_replay))\n",
-        "\n",
-        "for _ in range(100):\n",
-        "    obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "        10)\n",
-        "    assert obs_batch.shape == next_obs_batch.shape == (10,) + state_shape\n",
-        "    assert act_batch.shape == (\n",
-        "        10,), \"actions batch should have shape (10,) but is instead %s\" % str(act_batch.shape)\n",
-        "    assert reward_batch.shape == (\n",
-        "        10,), \"rewards batch should have shape (10,) but is instead %s\" % str(reward_batch.shape)\n",
-        "    assert is_done_batch.shape == (\n",
-        "        10,), \"is_done batch should have shape (10,) but is instead %s\" % str(is_done_batch.shape)\n",
-        "    assert [int(i) in (0, 1)\n",
-        "            for i in is_dones], \"is_done should be strictly True or False\"\n",
-        "    assert [\n",
-        "        0 <= a < n_actions for a in act_batch], \"actions should be within [0, n_actions]\"\n",
-        "\n",
-        "print(\"Well done!\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "fIINg1jmrwrS"
-      },
-      "source": [
-        "### Target networks\n",
-        "\n",
-        "We also employ the so called \"target network\" - a copy of neural network weights to be used for reference Q-values:\n",
-        "\n",
-        "The network itself is an exact copy of agent network, but it's parameters are not trained. Instead, they are moved here from agent's actual network every so often.\n",
-        "\n",
-        "$$ Q_{reference}(s,a) = r + \\gamma \\cdot \\max _{a'} Q_{target}(s',a') $$\n",
-        "\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/target_net.png)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "X5ENXyAcrwrU",
-        "colab": {}
-      },
-      "source": [
-        "target_network = DQNAgent(agent.state_shape, agent.n_actions, epsilon=0.5).to(device)\n",
-        "# This is how you can load weights from agent into target network\n",
-        "target_network.load_state_dict(agent.state_dict())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "BPtqsRzOrwrY"
-      },
-      "source": [
-        "### Learning with... Q-learning\n",
-        "Here we write a function similar to `agent.update` from tabular q-learning."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "DBq-u8gZrwrZ"
-      },
-      "source": [
-        "Compute Q-learning TD error:\n",
-        "\n",
-        "$$ L = { 1 \\over N} \\sum_i [ Q_{\\theta}(s,a) - Q_{reference}(s,a) ] ^2 $$\n",
-        "\n",
-        "With Q-reference defined as\n",
-        "\n",
-        "$$ Q_{reference}(s,a) = r(s,a) + \\gamma \\cdot max_{a'} Q_{target}(s', a') $$\n",
-        "\n",
-        "Where\n",
-        "* $Q_{target}(s',a')$ denotes q-value of next state and next action predicted by __target_network__\n",
-        "* $s, a, r, s'$ are current state, action, reward and next state respectively\n",
-        "* $\\gamma$ is a discount factor defined two cells above.\n",
-        "\n",
-        "\n",
-        "__Note 1:__ there's an example input below. Feel free to experiment with it before you write the function.\n",
-        "\n",
-        "__Note 2:__ compute_td_loss is a source of 99% of bugs in this homework. If reward doesn't improve, it often helps to go through it line by line [with a rubber duck](https://rubberduckdebugging.com/)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "x90TDrecrwra",
-        "colab": {}
-      },
-      "source": [
-        "def compute_td_loss(states, actions, rewards, next_states, is_done,\n",
-        "                    agent, target_network,\n",
-        "                    gamma=0.99,\n",
-        "                    check_shapes=False,\n",
-        "                    device=device):\n",
-        "    \"\"\" Compute td loss using torch operations only. Use the formulae above. \"\"\"\n",
-        "    states = torch.tensor(states, device=device, dtype=torch.float)    # shape: [batch_size, *state_shape]\n",
-        "\n",
-        "    # for some torch reason should not make actions a tensor\n",
-        "    actions = torch.tensor(actions, device=device, dtype=torch.long)    # shape: [batch_size]\n",
-        "    rewards = torch.tensor(rewards, device=device, dtype=torch.float)  # shape: [batch_size]\n",
-        "    # shape: [batch_size, *state_shape]\n",
-        "    next_states = torch.tensor(next_states, device=device, dtype=torch.float)\n",
-        "    is_done = torch.tensor(\n",
-        "        is_done.astype('float32'),\n",
-        "        device=device,\n",
-        "        dtype=torch.float\n",
-        "    )  # shape: [batch_size]\n",
-        "    is_not_done = 1 - is_done\n",
-        "\n",
-        "    # get q-values for all actions in current states\n",
-        "    predicted_qvalues = agent(states)\n",
-        "\n",
-        "    # compute q-values for all actions in next states\n",
-        "    predicted_next_qvalues = target_network(next_states)\n",
-        "    \n",
-        "    # select q-values for chosen actions\n",
-        "    predicted_qvalues_for_actions = predicted_qvalues[range(\n",
-        "        len(actions)), actions]\n",
-        "\n",
-        "    # compute V*(next_states) using predicted next q-values\n",
-        "    next_state_values = <YOUR CODE>\n",
-        "\n",
-        "    assert next_state_values.dim(\n",
-        "    ) == 1 and next_state_values.shape[0] == states.shape[0], \"must predict one value per state\"\n",
-        "\n",
-        "    # compute \"target q-values\" for loss - it's what's inside square parentheses in the above formula.\n",
-        "    # at the last state use the simplified formula: Q(s,a) = r(s,a) since s' doesn't exist\n",
-        "    # you can multiply next state values by is_not_done to achieve this.\n",
-        "    target_qvalues_for_actions = <YOUR CODE>\n",
-        "\n",
-        "    # mean squared error loss to minimize\n",
-        "    loss = torch.mean((predicted_qvalues_for_actions -\n",
-        "                       target_qvalues_for_actions.detach()) ** 2)\n",
-        "\n",
-        "    if check_shapes:\n",
-        "        assert predicted_next_qvalues.data.dim(\n",
-        "        ) == 2, \"make sure you predicted q-values for all actions in next state\"\n",
-        "        assert next_state_values.data.dim(\n",
-        "        ) == 1, \"make sure you computed V(s') as maximum over just the actions axis and not all axes\"\n",
-        "        assert target_qvalues_for_actions.data.dim(\n",
-        "        ) == 1, \"there's something wrong with target q-values, they must be a vector\"\n",
-        "\n",
-        "    return loss"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Hzt6cyBLrwrd"
-      },
-      "source": [
-        "Sanity checks"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "2Sl7sw0Krwre",
-        "colab": {}
-      },
-      "source": [
-        "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "    10)\n",
-        "\n",
-        "loss = compute_td_loss(obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch,\n",
-        "                       agent, target_network,\n",
-        "                       gamma=0.99, check_shapes=True)\n",
-        "loss.backward()\n",
-        "\n",
-        "assert loss.requires_grad and tuple(loss.data.size()) == (\n",
-        "    ), \"you must return scalar loss - mean over batch\"\n",
-        "assert np.any(next(agent.parameters()).grad.data.cpu().numpy() !=\n",
-        "              0), \"loss must be differentiable w.r.t. network weights\"\n",
-        "assert np.all(next(target_network.parameters()).grad is None), \"target network should not have grads\""
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Odl3ZrKRrwri"
-      },
-      "source": [
-        "### Main loop\n",
-        "\n",
-        "It's time to put everything together and see if it learns anything."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ZNJa_mrBrwrk",
-        "colab": {}
-      },
-      "source": [
-        "from tqdm import trange\n",
-        "from IPython.display import clear_output\n",
-        "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "e_dMNpRmrwro",
-        "colab": {}
-      },
-      "source": [
-        "seed = <your favourite random seed>\n",
-        "random.seed(seed)\n",
-        "np.random.seed(seed)\n",
-        "torch.manual_seed(seed)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "37JT0DxOrwrs",
-        "colab": {}
-      },
-      "source": [
-        "env = make_env(seed)\n",
-        "state_dim = env.observation_space.shape\n",
-        "n_actions = env.action_space.n\n",
-        "state = env.reset()\n",
-        "\n",
-        "agent = DQNAgent(state_dim, n_actions, epsilon=1).to(device)\n",
-        "target_network = DQNAgent(state_dim, n_actions, epsilon=1).to(device)\n",
-        "target_network.load_state_dict(agent.state_dict())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "h6F6KjbDrwrw",
-        "colab": {}
-      },
-      "source": [
-        "exp_replay = ReplayBuffer(10**4)\n",
-        "for i in range(100):\n",
-        "    if not utils.is_enough_ram(min_available_gb=0.1):\n",
-        "        print(\"\"\"\n",
-        "            Less than 100 Mb RAM available. \n",
-        "            Make sure the buffer size in not too huge.\n",
-        "            Also check, maybe other processes consume RAM heavily.\n",
-        "            \"\"\"\n",
-        "             )\n",
-        "        break\n",
-        "    play_and_record(state, agent, env, exp_replay, n_steps=10**2)\n",
-        "    if len(exp_replay) == 10**4:\n",
-        "        break\n",
-        "print(len(exp_replay))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-0X9fsfVlSHx",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# # for something more complicated than CartPole\n",
-        "\n",
-        "# timesteps_per_epoch = 1\n",
-        "# batch_size = 32\n",
-        "# total_steps = 3 * 10**6\n",
-        "# decay_steps = 1 * 10**6\n",
-        "\n",
-        "# opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
-        "\n",
-        "# init_epsilon = 1\n",
-        "# final_epsilon = 0.1\n",
-        "\n",
-        "# loss_freq = 20\n",
-        "# refresh_target_network_freq = 1000\n",
-        "# eval_freq = 5000\n",
-        "\n",
-        "# max_grad_norm = 5000"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "IXYcWdhkrwry",
-        "colab": {}
-      },
-      "source": [
-        "timesteps_per_epoch = 1\n",
-        "batch_size = 32\n",
-        "total_steps = 4 * 10**4\n",
-        "decay_steps = 1 * 10**4\n",
-        "\n",
-        "opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
-        "\n",
-        "init_epsilon = 1\n",
-        "final_epsilon = 0.1\n",
-        "\n",
-        "loss_freq = 20\n",
-        "refresh_target_network_freq = 100\n",
-        "eval_freq = 1000\n",
-        "\n",
-        "max_grad_norm = 5000"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "dPpq953grwr2",
-        "colab": {}
-      },
-      "source": [
-        "mean_rw_history = []\n",
-        "td_loss_history = []\n",
-        "grad_norm_history = []\n",
-        "initial_state_v_history = []"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "TrttrwDIrwr5",
-        "colab": {}
-      },
-      "source": [
-        "state = env.reset()\n",
-        "for step in trange(total_steps + 1):\n",
-        "    if not utils.is_enough_ram():\n",
-        "        print('less that 100 Mb RAM available, freezing')\n",
-        "        print('make sure everything is ok and make KeyboardInterrupt to continue')\n",
-        "        try:\n",
-        "            while True:\n",
-        "                pass\n",
-        "        except KeyboardInterrupt:\n",
-        "            pass\n",
-        "\n",
-        "    agent.epsilon = utils.linear_decay(init_epsilon, final_epsilon, step, decay_steps)\n",
-        "\n",
-        "    # play\n",
-        "    _, state = play_and_record(state, agent, env, exp_replay, timesteps_per_epoch)\n",
-        "\n",
-        "    # train\n",
-        "    < sample batch_size of data from experience replay >\n",
-        "\n",
-        "    loss = < compute TD loss >\n",
-        "\n",
-        "    loss.backward()\n",
-        "    grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), max_grad_norm)\n",
-        "    opt.step()\n",
-        "    opt.zero_grad()\n",
-        "\n",
-        "    if step % loss_freq == 0:\n",
-        "        td_loss_history.append(loss.data.cpu().item())\n",
-        "        grad_norm_history.append(grad_norm)\n",
-        "\n",
-        "    if step % refresh_target_network_freq == 0:\n",
-        "        # Load agent weights into target_network\n",
-        "        <YOUR CODE >\n",
-        "\n",
-        "    if step % eval_freq == 0:\n",
-        "        # eval the agent\n",
-        "        mean_rw_history.append(evaluate(\n",
-        "            make_env(seed=step), agent, n_games=3, greedy=True, t_max=1000)\n",
-        "        )\n",
-        "        initial_state_q_values = agent.get_qvalues(\n",
-        "            [make_env(seed=step).reset()]\n",
-        "        )\n",
-        "        initial_state_v_history.append(np.max(initial_state_q_values))\n",
-        "\n",
-        "        clear_output(True)\n",
-        "        print(\"buffer size = %i, epsilon = %.5f\" %\n",
-        "              (len(exp_replay), agent.epsilon))\n",
-        "\n",
-        "        plt.figure(figsize=[16, 9])\n",
-        "        plt.subplot(2, 2, 1)\n",
-        "        plt.title(\"Mean reward per episode\")\n",
-        "        plt.plot(mean_rw_history)\n",
-        "        plt.grid()\n",
-        "\n",
-        "        assert not np.isnan(td_loss_history[-1])\n",
-        "        plt.subplot(2, 2, 2)\n",
-        "        plt.title(\"TD loss history (smoothened)\")\n",
-        "        plt.plot(utils.smoothen(td_loss_history))\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.subplot(2, 2, 3)\n",
-        "        plt.title(\"Initial state V\")\n",
-        "        plt.plot(initial_state_v_history)\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.subplot(2, 2, 4)\n",
-        "        plt.title(\"Grad norm history (smoothened)\")\n",
-        "        plt.plot(utils.smoothen(grad_norm_history))\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "3WPUA6ZBrwr8",
-        "colab": {}
-      },
-      "source": [
-        "final_score = evaluate(\n",
-        "  make_env(),\n",
-        "  agent, n_games=30, greedy=True, t_max=1000\n",
-        ")\n",
-        "print('final score:', final_score)\n",
-        "assert final_score > 300, 'not good enough for DQN'\n",
-        "print('Well done')"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_d-qOt-BlSIK",
-        "colab_type": "text"
-      },
-      "source": [
-        "**Agent's predicted V-values vs their Monte-Carlo estimates**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "e5agCpPFrwsB",
-        "colab": {}
-      },
-      "source": [
-        "eval_env = make_env()\n",
-        "record = utils.play_and_log_episode(eval_env, agent)\n",
-        "print('total reward for life:', np.sum(record['rewards']))\n",
-        "for key in record:\n",
-        "    print(key)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "nndSeQwzlSIQ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "fig = plt.figure(figsize=(5, 5))\n",
-        "ax = fig.add_subplot(1, 1, 1)\n",
-        "\n",
-        "ax.scatter(record['v_mc'], record['v_agent'])\n",
-        "ax.plot(sorted(record['v_mc']), sorted(record['v_mc']),\n",
-        "       'black', linestyle='--', label='x=y')\n",
-        "\n",
-        "ax.grid()\n",
-        "ax.legend()\n",
-        "ax.set_title('State Value Estimates')\n",
-        "ax.set_xlabel('Monte-Carlo')\n",
-        "ax.set_ylabel('Agent')\n",
-        "\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "setup complete\n",
+      "Starting virtual X frame buffer: Xvfb.\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "# in google colab uncomment this\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "os.system('apt-get update')\n",
+    "os.system('apt-get install -y xvfb')\n",
+    "os.system('wget https://raw.githubusercontent.com/yandexdataschool/Practical_DL/fall18/xvfb -O ../xvfb')\n",
+    "os.system('apt-get install -y python-opengl ffmpeg')\n",
+    "os.system('pip install pyglet==1.5.0')\n",
+    "\n",
+    "os.system('python -m pip install -U pygame --user')\n",
+    "os.system('pip install gym[box2d]')\n",
+    "\n",
+    "prefix = 'https://raw.githubusercontent.com/yandexdataschool/Practical_RL/master/week04_approx_rl/'\n",
+    "\n",
+    "os.system('wget ' + prefix + 'atari_wrappers.py')\n",
+    "os.system('wget ' + prefix + 'utils.py')\n",
+    "os.system('wget ' + prefix + 'replay_buffer.py')\n",
+    "os.system('wget ' + prefix + 'framebuffer.py')\n",
+    "\n",
+    "print('setup complete')\n",
+    "\n",
+    "# XVFB will be launched if you run on a server\n",
+    "import os\n",
+    "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
+    "    !bash ../xvfb start\n",
+    "    os.environ['DISPLAY'] = ':1'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Frameworks__ - we'll accept this homework in any deep learning framework. This particular notebook was designed for pytoch, but you find it easy to adapt it to almost any python-based deep learning framework."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CartPole again\n",
+    "\n",
+    "Another env can be used without any modification of the code. State space should be a single vector, actions should be discrete.\n",
+    "\n",
+    "CartPole is the simplest one. It should take several minutes to solve it.\n",
+    "\n",
+    "For LunarLander it can take 1-2 hours to get 200 points (a good score) on Colab and training progress does not look informative."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_NAME = 'CartPole-v1'\n",
+    "\n",
+    "def make_env(seed=None):\n",
+    "    # some envs are wrapped with a time limit wrapper by default\n",
+    "    env = gym.make(ENV_NAME).unwrapped\n",
+    "    if seed is not None:\n",
+    "        env.seed(seed)\n",
+    "    return env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
+      "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARSUlEQVR4nO3df6zddX3H8edLQHRqBsi16fpjRe1i\ncJnF3SFG/0CMCsSsmjgDW6QxJJclmGBitoFLpiYj0WTKZuaINTDr4kTmj9AQNsVKYvxDsMVaWxC5\nagltKi0KqDFjK773x/0Uz+ot99wfh9vPPc9HcnK+3/f38z3n/YmHl99++j09qSokSf14znI3IEma\nH4NbkjpjcEtSZwxuSeqMwS1JnTG4JakzIwvuJBcneSDJdJJrR/U+kjRuMor7uJOcAvwAeBNwAPg2\ncHlV3bfkbyZJY2ZUV9znA9NV9aOq+h/gFmDziN5LksbKqSN63TXAwwP7B4DXnGjw2WefXRs2bBhR\nK5LUn/379/Poo49mtmOjCu45JZkCpgDWr1/Pzp07l6sVSTrpTE5OnvDYqJZKDgLrBvbXttrTqmpr\nVU1W1eTExMSI2pCklWdUwf1tYGOSc5I8F7gM2D6i95KksTKSpZKqOprkPcBXgFOAm6tq3yjeS5LG\nzcjWuKvqDuCOUb2+JI0rvzkpSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmd\nMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4Jakzi/rpsiT7gV8ATwFHq2oy\nyVnA54ENwH7gnVX12OLalCQdsxRX3G+oqk1VNdn2rwV2VNVGYEfblyQtkVEslWwGtrXtbcDbRvAe\nkjS2FhvcBXw1ya4kU622qqoOte2fAKsW+R6SpAGLWuMGXl9VB5O8BLgzyfcHD1ZVJanZTmxBPwWw\nfv36RbYhSeNjUVfcVXWwPR8GvgycDzySZDVAez58gnO3VtVkVU1OTEwspg1JGisLDu4kL0jyomPb\nwJuBvcB2YEsbtgW4bbFNSpJ+YzFLJauALyc59jr/XlX/leTbwK1JrgQeAt65+DYlSccsOLir6kfA\nq2ap/xR442KakiSdmN+clKTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4Jakzhjc\nktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjozZ3AnuTnJ4SR7B2pn\nJbkzyYPt+cxWT5KPJ5lOsifJq0fZvCSNo2GuuD8NXHxc7VpgR1VtBHa0fYBLgI3tMQXcuDRtSpKO\nmTO4q+obwM+OK28GtrXtbcDbBuqfqRnfAs5IsnqpmpUkLXyNe1VVHWrbPwFWte01wMMD4w602m9J\nMpVkZ5KdR44cWWAbkjR+Fv2Xk1VVQC3gvK1VNVlVkxMTE4ttQ5LGxkKD+5FjSyDt+XCrHwTWDYxb\n22qSpCWy0ODeDmxp21uA2wbqV7S7Sy4AnhhYUpEkLYFT5xqQ5HPAhcDZSQ4AHwA+DNya5ErgIeCd\nbfgdwKXANPAr4N0j6FmSxtqcwV1Vl5/g0BtnGVvA1YttSpJ0Yn5zUpI6Y3BLUmcMbknqjMEtSZ0x\nuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNb\nkjpjcEtSZ+YM7iQ3JzmcZO9A7YNJDibZ3R6XDhy7Lsl0kgeSvGVUjUvSuBrmivvTwMWz1G+oqk3t\ncQdAknOBy4BXtnP+JckpS9WsJGmI4K6qbwA/G/L1NgO3VNWTVfVjZn7t/fxF9CdJOs5i1rjfk2RP\nW0o5s9XWAA8PjDnQar8lyVSSnUl2HjlyZBFtSNJ4WWhw3wi8DNgEHAI+Ot8XqKqtVTVZVZMTExML\nbEOSxs+CgruqHqmqp6rq18Cn+M1yyEFg3cDQta0mSVoiCwruJKsHdt8OHLvjZDtwWZLTk5wDbATu\nWVyLkqRBp841IMnngAuBs5McAD4AXJhkE1DAfuAqgKral+RW4D7gKHB1VT01mtYlaTzNGdxVdfks\n5ZueYfz1wPWLaUqSdGJ+c1KSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1Zs7bAaWVbNfWq2at//HU\nJ5/lTqThecUtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1\nZs7gTrIuyV1J7kuyL8k1rX5WkjuTPNiez2z1JPl4kukke5K8etSTkKRxMswV91HgfVV1LnABcHWS\nc4FrgR1VtRHY0fYBLmHm1903AlPAjUvetSSNsTmDu6oOVdW9bfsXwP3AGmAzsK0N2wa8rW1vBj5T\nM74FnJFk9ZJ3Lkljal5r3Ek2AOcBdwOrqupQO/QTYFXbXgM8PHDagVY7/rWmkuxMsvPIkSPzbFuS\nxtfQwZ3khcAXgfdW1c8Hj1VVATWfN66qrVU1WVWTExMT8zlVksbaUMGd5DRmQvuzVfWlVn7k2BJI\nez7c6geBdQOnr201SdISGOaukgA3AfdX1ccGDm0HtrTtLcBtA/Ur2t0lFwBPDCypSJIWaZifLnsd\n8C7ge0l2t9r7gQ8Dtya5EngIeGc7dgdwKTAN/Ap495J2LEljbs7grqpvAjnB4TfOMr6AqxfZlyTp\nBPzmpHQcfyhYJzuDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1Jn\nDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjozzI8Fr0tyV5L7kuxLck2rfzDJwSS72+PS\ngXOuSzKd5IEkbxnlBCRp3AzzY8FHgfdV1b1JXgTsSnJnO3ZDVf3D4OAk5wKXAa8Efg/4WpI/qKqn\nlrJxSRpXc15xV9Whqrq3bf8CuB9Y8wynbAZuqaonq+rHzPza+/lL0awkaZ5r3Ek2AOcBd7fSe5Ls\nSXJzkjNbbQ3w8MBpB3jmoJeWxa6tV/1WzR8KVg+GDu4kLwS+CLy3qn4O3Ai8DNgEHAI+Op83TjKV\nZGeSnUeOHJnPqZI01oYK7iSnMRPan62qLwFU1SNV9VRV/Rr4FL9ZDjkIrBs4fW2r/T9VtbWqJqtq\ncmJiYjFzkKSxMsxdJQFuAu6vqo8N1FcPDHs7sLdtbwcuS3J6knOAjcA9S9eyJI23Ye4qeR3wLuB7\nSXa32vuBy5NsAgrYD1wFUFX7ktwK3MfMHSlXe0eJJC2dOYO7qr4JZJZDdzzDOdcD1y+iL0nSCfjN\nSUnqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCW\npM4Y3FpRkgz9GMX50rPB4JakzgzzQwrSinX7oamnt9+6eusydiINzytuja3B0J5tXzpZGdyS1Jlh\nfiz4eUnuSfLdJPuSfKjVz0lyd5LpJJ9P8txWP73tT7fjG0Y7BUkaL8NccT8JXFRVrwI2ARcnuQD4\nCHBDVb0ceAy4so2/Enis1W9o46STzvFr2q5xqxfD/FhwAb9su6e1RwEXAX/e6tuADwI3ApvbNsAX\ngH9OkvY60klj8qqtwG/C+oPL1ok0P0PdVZLkFGAX8HLgE8APgcer6mgbcgBY07bXAA8DVNXRJE8A\nLwYePdHr79q1y/ti1R0/s1ouQwV3VT0FbEpyBvBl4BWLfeMkU8AUwPr163nooYcW+5LSsxqm/iFS\nozQ5OXnCY/O6q6SqHgfuAl4LnJHkWPCvBQ627YPAOoB2/HeBn87yWlurarKqJicmJubThiSNtWHu\nKploV9okeT7wJuB+ZgL8HW3YFuC2tr297dOOf931bUlaOsMslawGtrV17ucAt1bV7UnuA25J8vfA\nd4Cb2vibgH9LMg38DLhsBH1L0tga5q6SPcB5s9R/BJw/S/2/gT9bku4kSb/Fb05KUmcMbknqjMEt\nSZ3xn3XViuINTBoHXnFLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J\n6ozBLUmdMbglqTMGtyR1xuCWpM4M82PBz0tyT5LvJtmX5EOt/ukkP06yuz02tXqSfDzJdJI9SV49\n6klI0jgZ5t/jfhK4qKp+meQ04JtJ/rMd+6uq+sJx4y8BNrbHa4Ab27MkaQnMecVdM37Zdk9rj2f6\n1+o3A59p530LOCPJ6sW3KkmCIde4k5ySZDdwGLizqu5uh65vyyE3JDm91dYADw+cfqDVJElLYKjg\nrqqnqmoTsBY4P8kfAtcBrwD+BDgL+Jv5vHGSqSQ7k+w8cuTIPNuWpPE1r7tKqupx4C7g4qo61JZD\nngT+FTi/DTsIrBs4bW2rHf9aW6tqsqomJyYmFta9JI2hYe4qmUhyRtt+PvAm4PvH1q2TBHgbsLed\nsh24ot1dcgHwRFUdGkn3kjSGhrmrZDWwLckpzAT9rVV1e5KvJ5kAAuwG/rKNvwO4FJgGfgW8e+nb\nlqTxNWdwV9Ue4LxZ6hedYHwBVy++NUnSbPzmpCR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1J\nnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZ\ng1uSOmNwS1JnDG5J6kyqarl7IMkvgAeWu48RORt4dLmbGIGVOi9YuXNzXn35/aqamO3Aqc92Jyfw\nQFVNLncTo5Bk50qc20qdF6zcuTmvlcOlEknqjMEtSZ05WYJ763I3MEIrdW4rdV6wcufmvFaIk+Iv\nJyVJwztZrrglSUNa9uBOcnGSB5JMJ7l2ufuZryQ3JzmcZO9A7awkdyZ5sD2f2epJ8vE21z1JXr18\nnT+zJOuS3JXkviT7klzT6l3PLcnzktyT5LttXh9q9XOS3N36/3yS57b66W1/uh3fsJz9zyXJKUm+\nk+T2tr9S5rU/yfeS7E6ys9W6/iwuxrIGd5JTgE8AlwDnApcnOXc5e1qATwMXH1e7FthRVRuBHW0f\nZua5sT2mgBufpR4X4ijwvqo6F7gAuLr9b9P73J4ELqqqVwGbgIuTXAB8BLihql4OPAZc2cZfCTzW\n6je0cSeza4D7B/ZXyrwA3lBVmwZu/ev9s7hwVbVsD+C1wFcG9q8DrlvOnhY4jw3A3oH9B4DVbXs1\nM/epA3wSuHy2cSf7A7gNeNNKmhvwO8C9wGuY+QLHqa3+9OcS+Arw2rZ9ahuX5e79BPNZy0yAXQTc\nDmQlzKv1uB84+7jaivkszvex3Esla4CHB/YPtFrvVlXVobb9E2BV2+5yvu2P0ecBd7MC5taWE3YD\nh4E7gR8Cj1fV0TZksPen59WOPwG8+NnteGj/CPw18Ou2/2JWxrwACvhqkl1Jplqt+8/iQp0s35xc\nsaqqknR7606SFwJfBN5bVT9P8vSxXudWVU8Bm5KcAXwZeMUyt7RoSd4KHK6qXUkuXO5+RuD1VXUw\nyUuAO5N8f/Bgr5/FhVruK+6DwLqB/bWt1rtHkqwGaM+HW72r+SY5jZnQ/mxVfamVV8TcAKrqceAu\nZpYQzkhy7EJmsPen59WO/y7w02e51WG8DvjTJPuBW5hZLvkn+p8XAFV1sD0fZub/bM9nBX0W52u5\ng/vbwMb2N9/PBS4Dti9zT0thO7ClbW9hZn34WP2K9rfeFwBPDPxR76SSmUvrm4D7q+pjA4e6nluS\niXalTZLnM7Nufz8zAf6ONuz4eR2b7zuAr1dbOD2ZVNV1VbW2qjYw89/R16vqL+h8XgBJXpDkRce2\ngTcDe+n8s7goy73IDlwK/ICZdca/Xe5+FtD/54BDwP8ys5Z2JTNrhTuAB4GvAWe1sWHmLpofAt8D\nJpe7/2eY1+uZWVfcA+xuj0t7nxvwR8B32rz2An/X6i8F7gGmgf8ATm/157X96Xb8pcs9hyHmeCFw\n+0qZV5vDd9tj37Gc6P2zuJiH35yUpM4s91KJJGmeDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLU\nGYNbkjrzf0Ew7Is+EjUWAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "env = make_env()\n",
+    "env.reset()\n",
+    "plt.imshow(env.render(\"rgb_array\"))\n",
+    "state_shape, n_actions = env.observation_space.shape, env.action_space.n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Building a network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now need to build a neural network that can map observations to state q-values.\n",
+    "The model does not have to be huge yet. 1-2 hidden layers with < 200 neurons and ReLU activation will probably be enough. Batch normalization and dropout can spoil everything here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "# those who have a GPU but feel unfair to use it can uncomment:\n",
+    "# device = torch.device('cpu')\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DQNAgent(nn.Module):\n",
+    "    def __init__(self, state_shape, n_actions, epsilon=0):\n",
+    "\n",
+    "        super().__init__()\n",
+    "        self.epsilon = epsilon\n",
+    "        self.n_actions = n_actions\n",
+    "        self.state_shape = state_shape\n",
+    "        # Define your network body here. Please make sure agent is fully contained here\n",
+    "        assert len(state_shape) == 1\n",
+    "        state_dim = state_shape[0]\n",
+    "        <YOUR CODE>\n",
+    "\n",
+    "        \n",
+    "    def forward(self, state_t):\n",
+    "        \"\"\"\n",
+    "        takes agent's observation (tensor), returns qvalues (tensor)\n",
+    "        :param state_t: a batch states, shape = [batch_size, *state_dim=4]\n",
+    "        \"\"\"\n",
+    "        # Use your network to compute qvalues for given state\n",
+    "        qvalues = <YOUR CODE>\n",
+    "\n",
+    "        assert qvalues.requires_grad, \"qvalues must be a torch tensor with grad\"\n",
+    "        assert len(\n",
+    "            qvalues.shape) == 2 and qvalues.shape[0] == state_t.shape[0] and qvalues.shape[1] == n_actions\n",
+    "\n",
+    "        return qvalues\n",
+    "\n",
+    "    def get_qvalues(self, states):\n",
+    "        \"\"\"\n",
+    "        like forward, but works on numpy arrays, not tensors\n",
+    "        \"\"\"\n",
+    "        model_device = next(self.parameters()).device\n",
+    "        states = torch.tensor(states, device=model_device, dtype=torch.float32)\n",
+    "        qvalues = self.forward(states)\n",
+    "        return qvalues.data.cpu().numpy()\n",
+    "\n",
+    "    def sample_actions(self, qvalues):\n",
+    "        \"\"\"pick actions given qvalues. Uses epsilon-greedy exploration strategy. \"\"\"\n",
+    "        epsilon = self.epsilon\n",
+    "        batch_size, n_actions = qvalues.shape\n",
+    "\n",
+    "        random_actions = np.random.choice(n_actions, size=batch_size)\n",
+    "        best_actions = qvalues.argmax(axis=-1)\n",
+    "\n",
+    "        should_explore = np.random.choice(\n",
+    "            [0, 1], batch_size, p=[1-epsilon, epsilon])\n",
+    "        return np.where(should_explore, random_actions, best_actions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = DQNAgent(state_shape, n_actions, epsilon=0.5).to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's try out our agent to see if it raises any errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(env, agent, n_games=1, greedy=False, t_max=10000):\n",
+    "    \"\"\" Plays n_games full games. If greedy, picks actions as argmax(qvalues). Returns mean reward. \"\"\"\n",
+    "    rewards = []\n",
+    "    for _ in range(n_games):\n",
+    "        s = env.reset()\n",
+    "        reward = 0\n",
+    "        for _ in range(t_max):\n",
+    "            qvalues = agent.get_qvalues([s])\n",
+    "            action = qvalues.argmax(axis=-1)[0] if greedy else agent.sample_actions(qvalues)[0]\n",
+    "            s, r, done, _ = env.step(action)\n",
+    "            reward += r\n",
+    "            if done:\n",
+    "                break\n",
+    "\n",
+    "        rewards.append(reward)\n",
+    "    return np.mean(rewards)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluate(env, agent, n_games=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Experience replay\n",
+    "For this assignment, we provide you with experience replay buffer. If you implemented experience replay buffer in last week's assignment, you can copy-paste it here in main notebook **to get 2 bonus points**.\n",
+    "\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/exp_replay.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The interface is fairly simple:\n",
+    "* `exp_replay.add(obs, act, rw, next_obs, done)` - saves (s,a,r,s',done) tuple into the buffer\n",
+    "* `exp_replay.sample(batch_size)` - returns observations, actions, rewards, next_observations and is_done for `batch_size` random samples.\n",
+    "* `len(exp_replay)` - returns number of elements stored in replay buffer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from replay_buffer import ReplayBuffer\n",
+    "exp_replay = ReplayBuffer(10)\n",
+    "\n",
+    "for _ in range(30):\n",
+    "    exp_replay.add(env.reset(), env.action_space.sample(),\n",
+    "                   1.0, env.reset(), done=False)\n",
+    "\n",
+    "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "    5)\n",
+    "\n",
+    "assert len(exp_replay) == 10, \"experience replay size should be 10 because that's what maximum capacity is\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def play_and_record(initial_state, agent, env, exp_replay, n_steps=1):\n",
+    "    \"\"\"\n",
+    "    Play the game for exactly n steps, record every (s,a,r,s', done) to replay buffer. \n",
+    "    Whenever game ends, add record with done=True and reset the game.\n",
+    "    It is guaranteed that env has done=False when passed to this function.\n",
+    "\n",
+    "    PLEASE DO NOT RESET ENV UNLESS IT IS \"DONE\"\n",
+    "\n",
+    "    :returns: return sum of rewards over time and the state in which the env stays\n",
+    "    \"\"\"\n",
+    "    s = initial_state\n",
+    "    sum_rewards = 0\n",
+    "\n",
+    "    # Play the game for n_steps as per instructions above\n",
+    "    <YOUR CODE >\n",
+    "\n",
+    "    return sum_rewards, s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing your code.\n",
+    "exp_replay = ReplayBuffer(2000)\n",
+    "\n",
+    "state = env.reset()\n",
+    "play_and_record(state, agent, env, exp_replay, n_steps=1000)\n",
+    "\n",
+    "# if you're using your own experience replay buffer, some of those tests may need correction.\n",
+    "# just make sure you know what your code does\n",
+    "assert len(exp_replay) == 1000, \"play_and_record should have added exactly 1000 steps, \"\\\n",
+    "                                 \"but instead added %i\" % len(exp_replay)\n",
+    "is_dones = list(zip(*exp_replay._storage))[-1]\n",
+    "\n",
+    "assert 0 < np.mean(is_dones) < 0.1, \"Please make sure you restart the game whenever it is 'done' and record the is_done correctly into the buffer.\"\\\n",
+    "                                    \"Got %f is_done rate over %i steps. [If you think it's your tough luck, just re-run the test]\" % (\n",
+    "                                        np.mean(is_dones), len(exp_replay))\n",
+    "\n",
+    "for _ in range(100):\n",
+    "    obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "        10)\n",
+    "    assert obs_batch.shape == next_obs_batch.shape == (10,) + state_shape\n",
+    "    assert act_batch.shape == (\n",
+    "        10,), \"actions batch should have shape (10,) but is instead %s\" % str(act_batch.shape)\n",
+    "    assert reward_batch.shape == (\n",
+    "        10,), \"rewards batch should have shape (10,) but is instead %s\" % str(reward_batch.shape)\n",
+    "    assert is_done_batch.shape == (\n",
+    "        10,), \"is_done batch should have shape (10,) but is instead %s\" % str(is_done_batch.shape)\n",
+    "    assert [int(i) in (0, 1)\n",
+    "            for i in is_dones], \"is_done should be strictly True or False\"\n",
+    "    assert [\n",
+    "        0 <= a < n_actions for a in act_batch], \"actions should be within [0, n_actions]\"\n",
+    "\n",
+    "print(\"Well done!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Target networks\n",
+    "\n",
+    "We also employ the so called \"target network\" - a copy of neural network weights to be used for reference Q-values:\n",
+    "\n",
+    "The network itself is an exact copy of agent network, but it's parameters are not trained. Instead, they are moved here from agent's actual network every so often.\n",
+    "\n",
+    "$$ Q_{reference}(s,a) = r + \\gamma \\cdot \\max _{a'} Q_{target}(s',a') $$\n",
+    "\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/target_net.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_network = DQNAgent(agent.state_shape, agent.n_actions, epsilon=0.5).to(device)\n",
+    "# This is how you can load weights from agent into target network\n",
+    "target_network.load_state_dict(agent.state_dict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Learning with... Q-learning\n",
+    "Here we write a function similar to `agent.update` from tabular q-learning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute Q-learning TD error:\n",
+    "\n",
+    "$$ L = { 1 \\over N} \\sum_i [ Q_{\\theta}(s,a) - Q_{reference}(s,a) ] ^2 $$\n",
+    "\n",
+    "With Q-reference defined as\n",
+    "\n",
+    "$$ Q_{reference}(s,a) = r(s,a) + \\gamma \\cdot max_{a'} Q_{target}(s', a') $$\n",
+    "\n",
+    "Where\n",
+    "* $Q_{target}(s',a')$ denotes q-value of next state and next action predicted by __target_network__\n",
+    "* $s, a, r, s'$ are current state, action, reward and next state respectively\n",
+    "* $\\gamma$ is a discount factor defined two cells above.\n",
+    "\n",
+    "\n",
+    "__Note 1:__ there's an example input below. Feel free to experiment with it before you write the function.\n",
+    "\n",
+    "__Note 2:__ compute_td_loss is a source of 99% of bugs in this homework. If reward doesn't improve, it often helps to go through it line by line [with a rubber duck](https://rubberduckdebugging.com/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_td_loss(states, actions, rewards, next_states, is_done,\n",
+    "                    agent, target_network,\n",
+    "                    gamma=0.99,\n",
+    "                    check_shapes=False,\n",
+    "                    device=device):\n",
+    "    \"\"\" Compute td loss using torch operations only. Use the formulae above. \"\"\"\n",
+    "    states = torch.tensor(states, device=device, dtype=torch.float)    # shape: [batch_size, *state_shape]\n",
+    "\n",
+    "    # for some torch reason should not make actions a tensor\n",
+    "    actions = torch.tensor(actions, device=device, dtype=torch.long)    # shape: [batch_size]\n",
+    "    rewards = torch.tensor(rewards, device=device, dtype=torch.float)  # shape: [batch_size]\n",
+    "    # shape: [batch_size, *state_shape]\n",
+    "    next_states = torch.tensor(next_states, device=device, dtype=torch.float)\n",
+    "    is_done = torch.tensor(\n",
+    "        is_done.astype('float32'),\n",
+    "        device=device,\n",
+    "        dtype=torch.float\n",
+    "    )  # shape: [batch_size]\n",
+    "    is_not_done = 1 - is_done\n",
+    "\n",
+    "    # get q-values for all actions in current states\n",
+    "    predicted_qvalues = agent(states)\n",
+    "\n",
+    "    # compute q-values for all actions in next states\n",
+    "    predicted_next_qvalues = target_network(next_states)\n",
+    "    \n",
+    "    # select q-values for chosen actions\n",
+    "    predicted_qvalues_for_actions = predicted_qvalues[range(\n",
+    "        len(actions)), actions]\n",
+    "\n",
+    "    # compute V*(next_states) using predicted next q-values\n",
+    "    next_state_values = <YOUR CODE>\n",
+    "\n",
+    "    assert next_state_values.dim(\n",
+    "    ) == 1 and next_state_values.shape[0] == states.shape[0], \"must predict one value per state\"\n",
+    "\n",
+    "    # compute \"target q-values\" for loss - it's what's inside square parentheses in the above formula.\n",
+    "    # at the last state use the simplified formula: Q(s,a) = r(s,a) since s' doesn't exist\n",
+    "    # you can multiply next state values by is_not_done to achieve this.\n",
+    "    target_qvalues_for_actions = <YOUR CODE>\n",
+    "\n",
+    "    # mean squared error loss to minimize\n",
+    "    loss = torch.mean((predicted_qvalues_for_actions -\n",
+    "                       target_qvalues_for_actions.detach()) ** 2)\n",
+    "\n",
+    "    if check_shapes:\n",
+    "        assert predicted_next_qvalues.data.dim(\n",
+    "        ) == 2, \"make sure you predicted q-values for all actions in next state\"\n",
+    "        assert next_state_values.data.dim(\n",
+    "        ) == 1, \"make sure you computed V(s') as maximum over just the actions axis and not all axes\"\n",
+    "        assert target_qvalues_for_actions.data.dim(\n",
+    "        ) == 1, \"there's something wrong with target q-values, they must be a vector\"\n",
+    "\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sanity checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "    10)\n",
+    "\n",
+    "loss = compute_td_loss(obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch,\n",
+    "                       agent, target_network,\n",
+    "                       gamma=0.99, check_shapes=True)\n",
+    "loss.backward()\n",
+    "\n",
+    "assert loss.requires_grad and tuple(loss.data.size()) == (\n",
+    "    ), \"you must return scalar loss - mean over batch\"\n",
+    "assert np.any(next(agent.parameters()).grad.data.cpu().numpy() !=\n",
+    "              0), \"loss must be differentiable w.r.t. network weights\"\n",
+    "assert np.all(next(target_network.parameters()).grad is None), \"target network should not have grads\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Main loop\n",
+    "\n",
+    "It's time to put everything together and see if it learns anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import trange\n",
+    "from IPython.display import clear_output\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seed = <your favourite random seed>\n",
+    "random.seed(seed)\n",
+    "np.random.seed(seed)\n",
+    "torch.manual_seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = make_env(seed)\n",
+    "state_dim = env.observation_space.shape\n",
+    "n_actions = env.action_space.n\n",
+    "state = env.reset()\n",
+    "\n",
+    "agent = DQNAgent(state_dim, n_actions, epsilon=1).to(device)\n",
+    "target_network = DQNAgent(state_dim, n_actions, epsilon=1).to(device)\n",
+    "target_network.load_state_dict(agent.state_dict())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp_replay = ReplayBuffer(10**4)\n",
+    "for i in range(100):\n",
+    "    if not utils.is_enough_ram(min_available_gb=0.1):\n",
+    "        print(\"\"\"\n",
+    "            Less than 100 Mb RAM available. \n",
+    "            Make sure the buffer size in not too huge.\n",
+    "            Also check, maybe other processes consume RAM heavily.\n",
+    "            \"\"\"\n",
+    "             )\n",
+    "        break\n",
+    "    play_and_record(state, agent, env, exp_replay, n_steps=10**2)\n",
+    "    if len(exp_replay) == 10**4:\n",
+    "        break\n",
+    "print(len(exp_replay))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # for something more complicated than CartPole\n",
+    "\n",
+    "# timesteps_per_epoch = 1\n",
+    "# batch_size = 32\n",
+    "# total_steps = 3 * 10**6\n",
+    "# decay_steps = 1 * 10**6\n",
+    "\n",
+    "# opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
+    "\n",
+    "# init_epsilon = 1\n",
+    "# final_epsilon = 0.1\n",
+    "\n",
+    "# loss_freq = 20\n",
+    "# refresh_target_network_freq = 1000\n",
+    "# eval_freq = 5000\n",
+    "\n",
+    "# max_grad_norm = 5000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timesteps_per_epoch = 1\n",
+    "batch_size = 32\n",
+    "total_steps = 4 * 10**4\n",
+    "decay_steps = 1 * 10**4\n",
+    "\n",
+    "opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
+    "\n",
+    "init_epsilon = 1\n",
+    "final_epsilon = 0.1\n",
+    "\n",
+    "loss_freq = 20\n",
+    "refresh_target_network_freq = 100\n",
+    "eval_freq = 1000\n",
+    "\n",
+    "max_grad_norm = 5000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_rw_history = []\n",
+    "td_loss_history = []\n",
+    "grad_norm_history = []\n",
+    "initial_state_v_history = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = env.reset()\n",
+    "for step in trange(total_steps + 1):\n",
+    "    if not utils.is_enough_ram():\n",
+    "        print('less that 100 Mb RAM available, freezing')\n",
+    "        print('make sure everything is ok and make KeyboardInterrupt to continue')\n",
+    "        try:\n",
+    "            while True:\n",
+    "                pass\n",
+    "        except KeyboardInterrupt:\n",
+    "            pass\n",
+    "\n",
+    "    agent.epsilon = utils.linear_decay(init_epsilon, final_epsilon, step, decay_steps)\n",
+    "\n",
+    "    # play\n",
+    "    _, state = play_and_record(state, agent, env, exp_replay, timesteps_per_epoch)\n",
+    "\n",
+    "    # train\n",
+    "    < sample batch_size of data from experience replay >\n",
+    "\n",
+    "    loss = < compute TD loss >\n",
+    "\n",
+    "    loss.backward()\n",
+    "    grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), max_grad_norm)\n",
+    "    opt.step()\n",
+    "    opt.zero_grad()\n",
+    "\n",
+    "    if step % loss_freq == 0:\n",
+    "        td_loss_history.append(loss.data.cpu().item())\n",
+    "        grad_norm_history.append(grad_norm)\n",
+    "\n",
+    "    if step % refresh_target_network_freq == 0:\n",
+    "        # Load agent weights into target_network\n",
+    "        <YOUR CODE >\n",
+    "\n",
+    "    if step % eval_freq == 0:\n",
+    "        # eval the agent\n",
+    "        mean_rw_history.append(evaluate(\n",
+    "            make_env(seed=step), agent, n_games=3, greedy=True, t_max=1000)\n",
+    "        )\n",
+    "        initial_state_q_values = agent.get_qvalues(\n",
+    "            [make_env(seed=step).reset()]\n",
+    "        )\n",
+    "        initial_state_v_history.append(np.max(initial_state_q_values))\n",
+    "\n",
+    "        clear_output(True)\n",
+    "        print(\"buffer size = %i, epsilon = %.5f\" %\n",
+    "              (len(exp_replay), agent.epsilon))\n",
+    "\n",
+    "        plt.figure(figsize=[16, 9])\n",
+    "        plt.subplot(2, 2, 1)\n",
+    "        plt.title(\"Mean reward per episode\")\n",
+    "        plt.plot(mean_rw_history)\n",
+    "        plt.grid()\n",
+    "\n",
+    "        assert not np.isnan(td_loss_history[-1])\n",
+    "        plt.subplot(2, 2, 2)\n",
+    "        plt.title(\"TD loss history (smoothened)\")\n",
+    "        plt.plot(utils.smoothen(td_loss_history))\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.subplot(2, 2, 3)\n",
+    "        plt.title(\"Initial state V\")\n",
+    "        plt.plot(initial_state_v_history)\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.subplot(2, 2, 4)\n",
+    "        plt.title(\"Grad norm history (smoothened)\")\n",
+    "        plt.plot(utils.smoothen(grad_norm_history))\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_score = evaluate(\n",
+    "  make_env(),\n",
+    "  agent, n_games=30, greedy=True, t_max=1000\n",
+    ")\n",
+    "print('final score:', final_score)\n",
+    "assert final_score > 300, 'not good enough for DQN'\n",
+    "print('Well done')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Agent's predicted V-values vs their Monte-Carlo estimates**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_env = make_env()\n",
+    "record = utils.play_and_log_episode(eval_env, agent)\n",
+    "print('total reward for life:', np.sum(record['rewards']))\n",
+    "for key in record:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(5, 5))\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "\n",
+    "ax.scatter(record['v_mc'], record['v_agent'])\n",
+    "ax.plot(sorted(record['v_mc']), sorted(record['v_mc']),\n",
+    "       'black', linestyle='--', label='x=y')\n",
+    "\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "ax.set_title('State Value Estimates')\n",
+    "ax.set_xlabel('Monte-Carlo')\n",
+    "ax.set_ylabel('Agent')\n",
+    "\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -1,1617 +1,1321 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "homework_pytorch_main.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.8"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deep Q-Network implementation.\n",
+    "\n",
+    "This homework shamelessly demands you to implement a DQN - an approximate q-learning algorithm with experience replay and target networks - and see if it works any better this way.\n",
+    "\n",
+    "Original paper:\n",
+    "https://arxiv.org/pdf/1312.5602.pdf"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "0ZUDhIV5Yr7E"
-      },
-      "source": [
-        "# Deep Q-Network implementation.\n",
-        "\n",
-        "This homework shamelessly demands you to implement a DQN - an approximate q-learning algorithm with experience replay and target networks - and see if it works any better this way.\n",
-        "\n",
-        "Original paper:\n",
-        "https://arxiv.org/pdf/1312.5602.pdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Wj-m84L9Yr7J"
-      },
-      "source": [
-        "**This notebook is the main notebook.** Another notebook is given for debug. (**homework_pytorch_main**). The tasks are similar and share most of the code. The main difference is in environments. In main notebook it can take some 2 hours for the agent to start improving so it seems reasonable to launch the algorithm on a simpler env first. In debug one it is CartPole and it will train in several minutes.\n",
-        "\n",
-        "**We suggest the following pipeline:** First implement debug notebook then implement the main one.\n",
-        "\n",
-        "**About evaluation:** All points are given for the main notebook with one exception: if agent fails to beat the threshold in main notebook you can get 1 pt (instead of 3 pts) for beating the threshold in debug notebook."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "bZHxPwHXYr7M",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "3a844fed-4fff-433c-f8a0-94b7c06222be"
-      },
-      "source": [
-        "# in google colab uncomment this\n",
-        "\n",
-        "import os\n",
-        "\n",
-        "os.system('apt-get update')\n",
-        "os.system('apt-get install -y xvfb')\n",
-        "os.system('wget https://raw.githubusercontent.com/yandexdataschool/Practical_DL/fall18/xvfb -O ../xvfb')\n",
-        "os.system('apt-get install -y python-opengl ffmpeg')\n",
-        "os.system('pip install pyglet==1.5.0')\n",
-        "\n",
-        "os.system('python -m pip install -U pygame --user')\n",
-        "\n",
-        "prefix = 'https://raw.githubusercontent.com/yandexdataschool/Practical_RL/master/week04_approx_rl/'\n",
-        "\n",
-        "os.system('wget ' + prefix + 'atari_wrappers.py')\n",
-        "os.system('wget ' + prefix + 'utils.py')\n",
-        "os.system('wget ' + prefix + 'replay_buffer.py')\n",
-        "os.system('wget ' + prefix + 'framebuffer.py')\n",
-        "\n",
-        "# print('setup complete')\n",
-        "\n",
-        "# XVFB will be launched if you run on a server\n",
-        "import os\n",
-        "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
-        "    !bash ../xvfb start\n",
-        "    os.environ['DISPLAY'] = ':1'"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Starting virtual X frame buffer: Xvfb.\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "tKaBf1GtYr7T"
-      },
-      "source": [
-        "__Frameworks__ - we'll accept this homework in any deep learning framework. This particular notebook was designed for pytoch, but you find it easy to adapt it to almost any python-based deep learning framework."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "LZTqx9P1Yr7V",
-        "colab": {}
-      },
-      "source": [
-        "import random\n",
-        "import numpy as np\n",
-        "import torch\n",
-        "import utils"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "uWqYSmVcYr7c",
-        "colab": {}
-      },
-      "source": [
-        "import gym\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "sz6wOVHUYr7i"
-      },
-      "source": [
-        "### Let's play some old videogames\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/nerd.png)\n",
-        "\n",
-        "This time we're gonna apply approximate q-learning to an atari game called Breakout. It's not the hardest thing out there, but it's definitely way more complex than anything we tried before.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "27wa-_YCYr7k",
-        "colab": {}
-      },
-      "source": [
-        "ENV_NAME = \"BreakoutNoFrameskip-v4\""
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "-ksb-dsaYr7q"
-      },
-      "source": [
-        "## Preprocessing (3 pts)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Pv3QqGcmYr7s"
-      },
-      "source": [
-        "Let's see what observations look like."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "xFHl47A_Yr7v",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 520
-        },
-        "outputId": "d830dc56-b5b8-4396-e045-7b58bf6aa638"
-      },
-      "source": [
-        "env = gym.make(ENV_NAME)\n",
-        "env.reset()\n",
-        "\n",
-        "n_cols = 5\n",
-        "n_rows = 2\n",
-        "fig = plt.figure(figsize=(16, 9))\n",
-        "\n",
-        "for row in range(n_rows):\n",
-        "    for col in range(n_cols):\n",
-        "        ax = fig.add_subplot(n_rows, n_cols, row * n_cols + col + 1)\n",
-        "        ax.imshow(env.render('rgb_array'))\n",
-        "        env.step(env.action_space.sample())\n",
-        "plt.show()"
-      ],
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6UAAAH3CAYAAABD+PmTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dbazkd3nf/8/1twMPNlQ2N7Us29SG\nOqmgah1YuVYL/GlpyGJFMfQBtVUFJ0VdkEBK5FSVCVJBlSK1aTASaupoEdaaKjHQOgSrclwcNwqq\nUhPWxDHmxtgmRni12AVXQJYIYvvbB+e3MFl295w9c/Od+Z7XSxqdOb+ZOXNZ+/bRXmfm/LZaawEA\nAIAe/r/eAwAAALB3WUoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG6WtpRW1YGqeqiqHqmq\nG5f1PNCDvhmdxhmdxhmdxtkktYx/p7Sqzkny5SQ/neTxJJ9Jcl1r7QsLfzJYMX0zOo0zOo0zOo2z\naZb1SumVSR5prX2ltfb9JB9Jcs2SngtWTd+MTuOMTuOMTuNslHOX9HUvSvK1mc8fT/IPZu9QVQeT\nHJw+feWS5oBZ32itvWgBX2fbvhON04XGGd3KGtc3HSyq70TjrKfTNr6spXRbrbVDSQ4lSVUt/j3E\n8KO+uson0zgdaJzRraxxfdOB7+GM7rSNL+vtu0eTXDLz+cXTMRiBvhmdxhmdxhmdxtkoy1pKP5Pk\n8qq6rKqek+TaJHcs6blg1fTN6DTO6DTO6DTORlnK23dba09X1TuT/I8k5yS5pbX2+WU816LddNNN\nO77vDTfcsOvHnvz4eR47r57PfbKTZ1nmc+3WJvedaHzVz30yjS+fxlf73CfT+HLpe7XPfbJN6DvR\n+G4er/EtvRpf2u+UttbuTHLnsr4+9KRvRqdxRqdxRqdxNkm3Ex1tgkX+9OVsHz/vc89jXX/qx+Jp\nnNFpnJHpm9FpfO9Y1u+UAgAAwLa8UsqP2O4nQXvxpzeMReOMTuOMTN+Mbi827pVSAAAAuvFKKdv+\ntGWV76GHZdA4o9M4I9M3o9O4V0oBAADoyCulZzDvTyXmefwqfyKyF376wqlpnNFpnJHpm9FpfO+o\n1lrvGVJV/YdgL7ivtba/xxNrnBXROKPr0ri+WRHfwxndaRv39l0AAAC6WYu371588cVDntqY9dKz\nMY2zChpndL0a0zer4Hs4oztTY14pBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC62fVSWlWX\nVNUfVtUXqurzVfVL0/H3VtXRqrp/uly9uHFhdTTO6DTOyPTN6DTOSOb5J2GeTvIrrbXPVtXzktxX\nVXdPt72/tfYb848HXWmc0Wmckemb0WmcYex6KW2tHUtybLr+nar6YpKLFjUY9KZxRqdxRqZvRqdx\nRrKQ3ymtqkuT/FSST0+H3llVD1TVLVV1/mkec7CqjlTVkePHjy9iDFgajTM6jTMyfTM6jbPp5l5K\nq+rHk9ye5Jdba99OcnOSlya5Ils/vXnfqR7XWjvUWtvfWtu/b9++eceApdE4o9M4I9M3o9M4I5hr\nKa2qH8vW/wS/3Vr73SRprT3RWnumtfZskg8muXL+MaEPjTM6jTMyfTM6jTOKec6+W0k+lOSLrbWb\nZo5fOHO3NyV5cPfjQT8aZ3QaZ2T6ZnQaZyTznH33HyX5+SSfq6r7p2O/muS6qroiSUvyWJK3zTUh\n9KNxRqdxRqZvRqdxhjHP2Xf/V5I6xU137n4cWB8aZ3QaZ2T6ZnQaZyTzvFK6MjfccEPvEdgAN910\n0/Z3WlMaZyc0zug2tXF9sxOb2neicXZmnsYX8k/CAAAAwG5YSgEAAOjGUgoAAEA3llIAAAC6sZQC\nAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUU\nAACAbs6d9wtU1WNJvpPkmSRPt9b2V9Xzk3w0yaVJHkvy5tba/533uWDV9M3oNM7oNM7I9M0oFvVK\n6T9urV3RWts/fX5jkntaa5cnuWf6HDaVvhmdxhmdxhmZvtl4y3r77jVJbp2u35rkjUt6HuhB34xO\n44xO44xM32ycRSylLcknq+q+qjo4HbugtXZsuv71JBec/KCqOlhVR6rqyPHjxxcwBizFrvpONM7G\n0Dij8/cURuZ7OEOY+3dKk7yqtXa0qv5mkrur6kuzN7bWWlW1kx/UWjuU5FCSXHLJJT9yO6yJXfU9\n3aZxNoHGGZ2/pzAy38MZwtyvlLbWjk4fn0zy8SRXJnmiqi5Mkunjk/M+D/Sgb0ancUancUamb0Yx\n11JaVfuq6nknrid5fZIHk9yR5Prpbtcn+cQ8zwM96JvRaZzRaZyR6ZuRzPv23QuSfLyqTnyt32mt\n3VVVn0nysap6a5KvJnnznM8DPeib0Wmc0WmckembYcy1lLbWvpLk75/i+DeTvG6erw296ZvRaZzR\naZyR6ZuRLOJER0t374EDvUdgA/xx7wHmoHF2QuOMblMb1zc7sal9JxpnZ+ZpfFn/TikAAABsy1IK\nAABAN5ZSAAAAurGUAgAA0I2lFAAAgG424uy7z/7tb/ceAZZK44xO44xM34xO4yybV0oBAADoxlIK\nAABAN5ZSAAAAurGUAgAA0I2lFAAAgG424uy7T/2N7/YeAZZK44xO44xM34xO4yybV0oBAADoxlIK\nAABAN7t++25V/WSSj84cekmSf5vkvCT/Ksn/mY7/amvtzl1PCJ1onNFpnNFpnJHpm5HseiltrT2U\n5IokqapzkhxN8vEkv5jk/a2131jIhNCJxhmdxhmdxhmZvhnJok509Lokj7bWvlpVC/qSP/TU3/n+\nwr8mA/rGUr+6xulP44xuQxvXNzuyoX0nGmeH5mh8Ub9Tem2S22Y+f2dVPVBVt1TV+Qt6DuhJ44xO\n44xO44xM32y0uZfSqnpOkp9L8l+nQzcneWm23k5wLMn7TvO4g1V1pKqOHD9+fN4xYGk0zug0zuh2\n07i+2RS+hzOCRbxS+oYkn22tPZEkrbUnWmvPtNaeTfLBJFee6kGttUOttf2ttf379u1bwBiwNBpn\ndBpndGfduL7ZIL6Hs/EWsZRel5m3C1TVhTO3vSnJgwt4DuhJ44xO44xO44xM32y8uU50VFX7kvx0\nkrfNHP71qroiSUvy2Em3wUbROKPTOKPTOCPTN6OYayltrR1P8oKTjv38XBOdwu88++JFf0kG9Pol\nfE2Ns040zug2tXF9sxOb2neicXZmnsYXdfZdAAAAOGuWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0\nM9fZd1fl+x95b+8R2ASv/+PeE+yaxtkRjTO6DW1c3+zIhvadaJwdmqNxr5QCAADQjaUUAACAbiyl\nAAAAdGMpBQAAoBtLKQAAAN1sxNl3/+ddV/UegQ3ws6+/qfcIu6ZxdkLjjG5TG9c3O7GpfScaZ2fm\nadwrpQAAAHRjKQUAAKAbSykAAADd7GgprapbqurJqnpw5tjzq+ruqnp4+nj+dLyq6gNV9UhVPVBV\nr1jW8LAI+mZ0Gmd0Gmdk+mYv2OkrpYeTHDjp2I1J7mmtXZ7knunzJHlDksuny8EkN88/JizV4eib\nsR2Oxhnb4WiccR2OvhncjpbS1tqnkjx10uFrktw6Xb81yRtnjn+4bbk3yXlVdeEihoVl0Dej0zij\n0zgj0zd7wTy/U3pBa+3YdP3rSS6Yrl+U5Gsz93t8OgabRN+MTuOMTuOMTN8MZSEnOmqttSTtbB5T\nVQer6khVHTl+/PgixoCl2E3ficbZHBpndP6ewsh8D2cE8yylT5x4O8D08cnp+NEkl8zc7+Lp2F/T\nWjvUWtvfWtu/b9++OcaApZir70TjrD2NMzp/T2FkvoczlHmW0juSXD9dvz7JJ2aOv2U6+9dVSb41\n8/YC2BT6ZnQaZ3QaZ2T6Zijn7uROVXVbktcmeWFVPZ7kPUn+fZKPVdVbk3w1yZunu9+Z5OokjyT5\nbpJfXPDMsFD6ZnQaZ3QaZ2T6Zi/Y0VLaWrvuNDe97hT3bUneMc9QsEr6ZnQaZ3QaZ2T6Zi9YyImO\nAAAAYDcspQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG4s\npQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAutl2Ka2qW6rqyap6cObYf6yqL1XV\nA1X18ao6bzp+aVX9ZVXdP11+a5nDwyJofL3ce+BA7j1woPcYQ9E4I9M3o9M4e8FOXik9nOTkvyHe\nneTvttb+XpIvJ3nXzG2PttaumC5vX8yYsFSHo3HGdjgaXwt+6LIUh6NvxnY4Gmdw2y6lrbVPJXnq\npGOfbK09PX16b5KLlzAbrITGGZ3GGZm+14MfuCyPxtkLFvE7pf8yye/PfH5ZVf1pVf1RVb16AV8f\netM4o9M4I9M3o9P4kvmhy/KdO8+Dq+rdSZ5O8tvToWNJXtxa+2ZVvTLJ71XVy1tr3z7FYw8mOZgk\n559//jxjwNJofPWuuuuu3iPsKRpnZPpmdBpnFLt+pbSqfiHJzyb5F621liStte+11r45Xb8vyaNJ\nfuJUj2+tHWqt7W+t7d+3b99ux4Cl0Tij0/jqXXXXXX7wsiL6ZnQaZyS7eqW0qg4k+TdJ/v/W2ndn\njr8oyVOttWeq6iVJLk/ylYVMCiukcUancUam79Xzw5bV0jij2XYprarbkrw2yQur6vEk78nWGb6e\nm+TuqkqSe6eze70myb+rqr9K8mySt7fWnjrlF4Y1oXFGp3FGpm9Gp/H+/NBl+bZdSltr153i8IdO\nc9/bk9w+71CwShpndBpnZPpmdBpnL1jE2XcBAABgVyylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjG\nUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3\nllIAAAC6sZQCAADQzbZLaVXdUlVPVtWDM8feW1VHq+r+6XL1zG3vqqpHquqhqvqZZQ0Oi6JxRqdx\nRqdxRqZv9oKdvFJ6OMmBUxx/f2vtiulyZ5JU1cuSXJvk5dNj/nNVnbOoYWFJDkfjjO1wNM7YDkfj\njOtw9M3gtl1KW2ufSvLUDr/eNUk+0lr7Xmvtz5M8kuTKOeaDpdM4o9M4o9M4I9M3e8E8v1P6zqp6\nYHpLwfnTsYuSfG3mPo9Px35EVR2sqiNVdeT48eNzjAFLo3FGp3FGt+vG9c0G8D2cYex2Kb05yUuT\nXJHkWJL3ne0XaK0daq3tb63t37dv3y7HgKXROKPTOKObq3F9s+Z8D2cou1pKW2tPtNaeaa09m+SD\n+eHbAo4muWTmrhdPx2CjaJzRaZzRaZyR6ZvR7GopraoLZz59U5ITZwO7I8m1VfXcqrosyeVJ/mS+\nEWH1NM7oNM7oNM7I9M1ozt3uDlV1W5LXJnlhVT2e5D1JXltVVyRpSR5L8rYkaa19vqo+luQLSZ5O\n8o7W2jPLGR0WQ+OMTuOMTuOMTN/sBdsupa21605x+ENnuP+vJfm1eYaCVdI4o9M4o9M4I9M3e8E8\nZ98FAACAuVhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0YykFAACgG0spAAAA\n3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0s+1SWlW3VNWTVfXgzLGPVtX9\n0+Wxqrp/On5pVf3lzG2/tczhYRE0zug0zsj0zeg0zl5w7g7uczjJf0ry4RMHWmv//MT1qnpfkm/N\n3P/R1toVixoQVuBwNM7YDkfjjOtw9M3YDkfjDG7bpbS19qmquvRUt1VVJXlzkn+y2LFgdTTO6DTO\nyPTN6DTOXjDv75S+OskTrbWHZ45dVlV/WlV/VFWvPt0Dq+pgVR2pqiPHjx+fcwxYGo0zOo0zMn0z\nOo0zhJ28ffdMrkty28znx5K8uLX2zap6ZZLfq6qXt9a+ffIDW2uHkhxKkksuuaTNOQcsi8YZncYZ\nmb4ZncYZwq5fKa2qc5P8syQfPXGstfa91to3p+v3JXk0yU/MOyT0oHFGp3FGpm9Gp3FGMs/bd/9p\nki+11h4/caCqXlRV50zXX5Lk8iRfmW9E6EbjjE7jjEzfjE7jDGMn/yTMbUn+d5KfrKrHq+qt003X\n5q+/XSBJXpPkgem01P8tydtba08tcmBYNI0zOo0zMn0zOo2zF+zk7LvXneb4L5zi2O1Jbp9/LFgd\njTM6jTMyfTM6jbMXzHv2XQAAANg1SykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAA\ngG62/XdKV+Fb5zyb/37eX/QeY0+698CBuR5/1V13LWiS+f3DT36y9winpfF+NL4aGu9H48un7370\nvRoa70fjW7xSCgAAQDeWUgAAALqxlAIAANDNWvxOKf2s0/vQYRk0zug0zsj0zeg0vsVSyjD8T83o\nNM7oNM7I9M3o5mm8WmsLHGWXQ1T1H4K94L7W2v4eT6xxVkTjjK5L4/pmRXwPZ3SnbdzvlAIAANDN\ntktpVV1SVX9YVV+oqs9X1S9Nx59fVXdX1cPTx/On41VVH6iqR6rqgap6xbL/I2AeGmd0Gmdk+mZ0\nGmcv2MkrpU8n+ZXW2suSXJXkHVX1siQ3JrmntXZ5knumz5PkDUkuny4Hk9y88KlhsTTO6DTOyPTN\n6DTO8LZdSltrx1prn52ufyfJF5NclOSaJLdOd7s1yRun69ck+XDbcm+S86rqwoVPDguicUancUam\nb0ancfaCs/qd0qq6NMlPJfl0kgtaa8emm76e5ILp+kVJvjbzsMenYyd/rYNVdaSqjpzlzLA0Gmd0\nGmdk+mZ0GmdUO15Kq+rHk9ye5Jdba9+eva1tncL3rM7a1Vo71Frb3+ssY3AyjTM6jTMyfTM6jTOy\nHS2lVfVj2fqf4Ldba787HX7ixFsBpo9PTsePJrlk5uEXT8dgbWmc0Wmckemb0Wmc0e3k7LuV5ENJ\nvthau2nmpjuSXD9dvz7JJ2aOv2U689dVSb4189YCWDsaZ3QaZ2T6ZnQaZ09orZ3xkuRV2Xo7wANJ\n7p8uVyd5QbbO9PVwkj9I8vzp/pXkN5M8muRzSfbv4Dmai8sKLkc07jL4ReMuo19+pPHo22Wci+/h\nLqNfTtl4ay01hdhVVfUfgr3gvl6/N6FxVkTjjK5L4/pmRXwPZ3Snbfyszr4LAAAAi2QpBQAAoBtL\nKQAAAN2c23uAyTeSHJ8+bqoXxvw97WT+v7WKQU5D4/3thfl7Nv4XSR7q+Pzz2gt9rLt1btz38P72\nwvz+njKfvdDIOpur8bU40VGSVNWRTf7He83f1ybMvwkznon5+1r3+dd9vu2Yv791/29Y9/m2Y/6+\nNmH+TZjxTMzf17zze/suAAAA3VhKAQAA6GadltJDvQeYk/n72oT5N2HGMzF/X+s+/7rPtx3z97fu\n/w3rPt92zN/XJsy/CTOeifn7mmv+tfmdUgAAAPaedXqlFAAAgD3GUgoAAEA33ZfSqjpQVQ9V1SNV\ndWPveXaiqh6rqs9V1f1VdWQ69vyquruqHp4+nt97zllVdUtVPVlVD84cO+XMteUD05/JA1X1in6T\n/2DWU83/3qo6Ov053F9VV8/c9q5p/oeq6mf6TP2DWTS+ZPruS+PLp/F+NrHvROOrpvHV2rS+E41v\n+wSttW6XJOckeTTJS5I8J8mfJXlZz5l2OPdjSV540rFfT3LjdP3GJP+h95wnzfeaJK9I8uB2Mye5\nOsnvJ6kkVyX59JrO/94k//oU933Z1NJzk1w2NXZOp7k13q8Pfa9mdo33a0Tjy597I/ueZtd4//k1\nvry5N6rvMzSi8enS+5XSK5M80lr7Smvt+0k+kuSazjPt1jVJbp2u35rkjR1n+RGttU8leeqkw6eb\n+ZokH25b7k1yXlVduJpJT+0085/ONUk+0lr7Xmvtz5M8kq3WetD4Cui7W9+JxldC476HL4jGl0Tj\na2Ft+040nm0a772UXpTkazOfPz4dW3ctySer6r6qOjgdu6C1dmy6/vUkF/QZ7aycbuZN+nN55/S2\nhltm3qaxTvOv0yxnY4TG9b0a6zbPTml8Pax74+s0y9nS+HrQ+HKM0Hei8R/ovZRuqle11l6R5A1J\n3lFVr5m9sW29br1R/9bOJs6c5OYkL01yRZJjSd7Xd5yhDNX4ps070fdyabw/jS+XxvvT+PIM1Xey\nmTNngY33XkqPJrlk5vOLp2NrrbV2dPr4ZJKPZ+vl6CdOvKw+fXyy34Q7drqZN+LPpbX2RGvtmdba\ns0k+mB++LWCd5l+nWXZskMb1vRrrNs+OaLy/DWl8nWY5KxrvT+PLM0jficZ/oPdS+pkkl1fVZVX1\nnCTXJrmj80xnVFX7qup5J64neX2SB7M19/XT3a5P8ok+E56V0818R5K3TGf+uirJt2beWrA2Tnpv\n/Zuy9eeQbM1/bVU9t6ouS3J5kj9Z9XwTjfej79XQeD8aX76N6zvR+LrQ+HIM1Hei8R8601mQVnHJ\n1tmlvpytszK9u/c8O5j3Jdk6m9SfJfn8iZmTvCDJPUkeTvIHSZ7fe9aT5r4tWy+r/1W23tf91tPN\nnK0zff3m9GfyuST713T+/zLN98AU/4Uz93/3NP9DSd7QeXaN9+lD36ubX+N9GtH4ambfqL6nmTW+\nHvNrfDnzblzfZ2hE49OlpgcBAADAyvV++y4AAAB7mKUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1Y\nSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjG\nUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3\nllIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6\nsZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQ\njaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN0sbSmtqgNV9VBVPVJVNy7reaAHfTM6jTM6jTM6jbNJ\nqrW2+C9adU6SLyf56SSPJ/lMkutaa19Y+JPBiumb0Wmc0Wmc0WmcTbOsV0qvTPJIa+0rrbXvJ/lI\nkmuW9FywavpmdBpndBpndBpno5y7pK97UZKvzXz+eJJ/MHuHqjqY5OD06SuXNAfM+kZr7UUL+Drb\n9p1onC40zuhW1ri+6WBRfScaZz2dtvFlLaXbaq0dSnIoSapq8e8hhh/11VU+mcbpQOOMbmWN65sO\nfA9ndKdtfFlv3z2a5JKZzy+ejsEI9M3oNM7oNM7oNM5GWdZS+pkkl1fVZVX1nCTXJrljSc8Fq6Zv\nRqdxRqdxRqdxNspS3r7bWnu6qt6Z5H8kOSfJLa21zy/juRbtpptu2vF9b7jhhl0/9uTHz/PYefV8\n7pOdPMsyn2u3NrnvROOrfu6TaXz5NL7a5z6ZxpdL36t97pNtQt+JxnfzeI1v6dX40n6ntLV2Z5I7\nl/X1oSd9MzqNMzqNMzqNs0m6nehoEyzypy9n+/h5n3se6/pTPxZP44xO44xM34xO43vHsn6nFAAA\nALbllVJ+xHY/CdqLP71hLBpndBpnZPpmdHuxca+UAgAA0I1XStn2py2rfA89LIPGGZ3GGZm+GZ3G\nvVIKAABAR14pPYN5fyoxz+NX+RORvfDTF05N44xO44xM34xO43tHtdZ6z5Cq6j8Ee8F9rbX9PZ5Y\n46yIxhldl8b1zYr4Hs7oTtu4t+8CAADQzVq8fffiiy8e8tTGrJeejWmcVdA4o+vVmL5ZBd/DGd2Z\nGvNKKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQza6X0qq6pKr+sKq+UFWfr6pfmo6/t6qO\nVtX90+XqxY0Lq6NxRqdxRqZvRqdxRjLPPwnzdJJfaa19tqqel+S+qrp7uu39rbXfmH886ErjjE7j\njEzfjE7jDGPXS2lr7ViSY9P171TVF5NctKjBoDeNMzqNMzJ9MzqNM5KF/E5pVV2a5KeSfHo69M6q\neqCqbqmq80/zmINVdaSqjhw/fnwRY8DSaJzRaZyR6ZvRaZxNN/dSWlU/nuT2JL/cWvt2kpuTvDTJ\nFdn66c37TvW41tqh1tr+1tr+ffv2zTsGLI3GGZ3GGZm+GZ3GGcFcS2lV/Vi2/if47dba7yZJa+2J\n1tozrbVnk3wwyZXzjwl9aJzRaZyR6ZvRaZxRzHP23UryoSRfbK3dNHP8wpm7vSnJg7sfD/rROKPT\nOCPTN6PTOCOZ5+y7/yjJzyf5XFXdPx371STXVdUVSVqSx5K8ba4JoR+NMzqNMzJ9MzqNM4x5zr77\nv5LUKW66c/fjwPrQOKPTOCPTN6PTOCOZ55XSlbnhhht6j8AGuOmmm7a/05rSODuhcUa3qY3rm53Y\n1L4TjbMz8zS+kH8SBgAAAHbDUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtL\nKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdHPuvF+gqh5L8p0kzyR5\nurW2v6qen+SjSS5N8liSN7fW/u+8zwWrpm9Gp3FGp3FGpm9GsahXSv9xa+2K1tr+6fMbk9zTWrs8\nyT3T57Cp9M3oNM7oNM7I9M3GW9bbd69Jcut0/dYkb1zS80AP+mZ0Gmd0Gmdk+mbjLGIpbUk+WVX3\nVdXB6dgFrbVj0/WvJ7ng5AdV1cGqOlJVR44fP76AMWApdtV3onE2hsYZnb+nMDLfwxnC3L9TmuRV\nrbWjVfU3k9xdVV+avbG11qqqnfyg1tqhJIeS5JJLLvmR22FN7Krv6TaNswk0zuj8PYWR+R7OEOZ+\npbS1dnT6+GSSjye5MskTVXVhkkwfn5z3eaAHfTM6jTM6jTMyfTOKuZbSqtpXVc87cT3J65M8mOSO\nJNdPd7s+ySfmeR7oQd+MTmOrsbMAABLfSURBVOOMTuOMTN+MZN63716Q5ONVdeJr/U5r7a6q+kyS\nj1XVW5N8Ncmb53we6EHfjE7jjE7jjEzfDGOupbS19pUkf/8Ux7+Z5HXzfG3oTd+MTuOMTuOMTN+M\nZBEnOlq6ew8c6D0CG+CPew8wB42zExpndJvauL7ZiU3tO9E4OzNP48v6d0oBAABgW5ZSAAAAurGU\nAgAA0I2lFAAAgG4spQAAAHSzEWffffZvf7v3CLBUGmd0Gmdk+mZ0GmfZvFIKAABAN5ZSAAAAurGU\nAgAA0I2lFAAAgG4spQAAAHSzEWfffepvfLf3CLBUGmd0Gmdk+mZ0GmfZvFIKAABAN5ZSAAAAutn1\n23er6ieTfHTm0EuS/Nsk5yX5V0n+z3T8V1trd+56QuhE44xO44xO44xM34xk10tpa+2hJFckSVWd\nk+Roko8n+cUk72+t/cZCJoRONM7oNM7oNM7I9M1IFnWio9clebS19tWqWtCX/KGn/s73F/41GdA3\nlvrVNU5/Gmd0G9q4vtmRDe070Tg7NEfji/qd0muT3Dbz+Tur6oGquqWqzj/VA6rqYFUdqaojx48f\nX9AYsDQaZ3QaZ3Rn1bi+2TC+h7PR5l5Kq+o5SX4uyX+dDt2c5KXZejvBsSTvO9XjWmuHWmv7W2v7\n9+3bN+8YsDQaZ3QaZ3S7aVzfbArfwxnBIl4pfUOSz7bWnkiS1toTrbVnWmvPJvlgkisX8BzQk8YZ\nncYZncYZmb7ZeItYSq/LzNsFqurCmdvelOTBBTwH9KRxRqdxRqdxRqZvNt5cJzqqqn1JfjrJ22YO\n/3pVXZGkJXnspNtgo2ic0Wmc0WmckembUcy1lLbWjid5wUnHfn6uiU7hd5598aK/JAN6/RK+psZZ\nJxpndJvauL7ZiU3tO9E4OzNP44s6+y4AAACcNUspAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqZ6+y7\nq/L9j7y39whsgtf/ce8Jdk3j7IjGGd2GNq5vdmRD+040zg7N0bhXSgEAAOjGUgoAAEA3llIAAAC6\nsZQCAADQjaUUAACAbjbi7Lv/866reo/ABvjZ19/Ue4Rd0zg7oXFGt6mN65ud2NS+E42zM/M07pVS\nAAAAurGUAgAA0I2lFAAAgG52tJRW1S1V9WRVPThz7PlVdXdVPTx9PH86XlX1gap6pKoeqKpXLGt4\nWAR9MzqNMzqNMzJ9sxfs9JXSw0kOnHTsxiT3tNYuT3LP9HmSvCHJ5dPlYJKb5x8Tlupw9M3YDkfj\njO1wNM64DkffDG5HS2lr7VNJnjrp8DVJbp2u35rkjTPHP9y23JvkvKq6cBHDwjLom9FpnNFpnJHp\nm71gnt8pvaC1dmy6/vUkF0zXL0rytZn7PT4d+2uq6mBVHamqI8ePH59jDFiKufpONM7a0zij8/cU\nRuZ7OENZyImOWmstSTvLxxxqre1vre3ft2/fIsaApdhN39PjNM5G0Dij8/cURuZ7OCOYZyl94sTb\nAaaPT07Hjya5ZOZ+F0/HYJPom9FpnNFpnJHpm6HMs5TekeT66fr1ST4xc/wt09m/rkryrZm3F8Cm\n0Dej0zij0zgj0zdDOXcnd6qq25K8NskLq+rxJO9J8u+TfKyq3prkq0nePN39ziRXJ3kkyXeT/OKC\nZ4aF0jej0zij0zgj0zd7wY6W0tbadae56XWnuG9L8o55hoJV0jej0zij0zgj0zd7wUJOdAQAAAC7\nYSkFAACgG0spAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0YykFAACg\nG0spAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANDNtktpVd1SVU9W1YMzx/5jVX2pqh6oqo9X\n1XnT8Uur6i+r6v7p8lvLHB4WQeOMTuOMTN+MTuPsBTt5pfRwkgMnHbs7yd9trf29JF9O8q6Z2x5t\nrV0xXd6+mDFhqQ5H44ztcDTOuA5H34ztcDTO4LZdSltrn0ry1EnHPtlae3r69N4kFy9hNlgJjTM6\njTMyfTM6jbMXLOJ3Sv9lkt+f+fyyqvrTqvqjqnr1Ar4+9KZxRqdxRqZvRqdxNt658zy4qt6d5Okk\nvz0dOpbkxa21b1bVK5P8XlW9vLX27VM89mCSg0ly/vnnzzPG0O49sPVujavuuqvzJHuTxhmdxhmZ\nvhmdxhnFrl8prapfSPKzSf5Fa60lSWvte621b07X70vyaJKfONXjW2uHWmv7W2v79+3bt9sxYGk0\nvnz3Hjjwgx+8sHoaZ2T6ZnQaZyS7Wkqr6kCSf5Pk51pr3505/qKqOme6/pIklyf5yiIGhVXSOKPT\n+PL5oUs/+mZ0Gmc02759t6puS/LaJC+sqseTvCdbZ/h6bpK7qypJ7p3O7vWaJP+uqv4qybNJ3t5a\ne+qUXxjWhMYZncYZmb5Xz68WrZbG2Qu2XUpba9ed4vCHTnPf25PcPu9Q/JBv+MuncUancUamb0an\n8dXyQ5c+5jrREcA8fMMHAMBSCgBL4IcuALAzllIAAHbMD1yARbOUAgAAxA9detn1v1MKAAAA87KU\nAgAA0I2lFAAAgG4spQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2l\nFAAAgG62XUqr6paqerKqHpw59t6qOlpV90+Xq2due1dVPVJVD1XVzyxrcFgUjTM6jTM6jTMyfbMX\n7OSV0sNJDpzi+Ptba1dMlzuTpKpeluTaJC+fHvOfq+qcRQ0LS3I4Gmdsh6NxxnY4Gmdch6NvBrft\nUtpa+1SSp3b49a5J8pHW2vdaa3+e5JEkV84xHyydxhmdxhmdxhmZvtkL5vmd0ndW1QPTWwrOn45d\nlORrM/d5fDoGm0jjjE7jjE7jjEzfDGO3S+nNSV6a5Iokx5K872y/QFUdrKojVXXk+PHjuxwDlkbj\njE7jjG6uxvXNmvM9nKHsailtrT3RWnumtfZskg/mh28LOJrkkpm7XjwdO9XXONRa299a279v377d\njAFLo3FGp3FGN2/j+mad+R7OaHa1lFbVhTOfvinJibOB3ZHk2qp6blVdluTyJH8y34iwehpndBpn\ndBpnZPpmNOdud4equi3Ja5O8sKoeT/KeJK+tqiuStCSPJXlbkrTWPl9VH0vyhSRPJ3lHa+2Z5YwO\ni6FxRqdxRqdxRqZv9oJtl9LW2nWnOPyhM9z/15L82jxDwSppnNFpnNFpnJHpm71gnrPvAgAAwFws\npQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG4spQAAAHRj\nKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAutl2Ka2qW6rqyap6cObYR6vq/unyWFXdPx2/\ntKr+cua231rm8LAIGmd0Gmdk+mZ0GmcvOHcH9zmc5D8l+fCJA621f37ielW9L8m3Zu7/aGvtikUN\nCCtwOBpnbIejccZ1OPpmbIejcQa37VLaWvtUVV16qtuqqpK8Ock/WexYsDoaZ3QaZ2T6ZnQaZy+Y\n93dKX53kidbawzPHLquqP62qP6qqV8/59aE3jTM6jTMyfTM6jTOEnbx990yuS3LbzOfHkry4tfbN\nqnplkt+rqpe31r598gOr6mCSg0ly/vnnzzkGLI3GGZ3GGZm+GZ3GGcKuXymtqnOT/LMkHz1xrLX2\nvdbaN6fr9yV5NMlPnOrxrbVDrbX9rbX9+/bt2+0YsDQaZ3QaZ2T6ZnQaZyTzvH33nyb5Umvt8RMH\nqupFVXXOdP0lSS5P8pX5RoRuNM7oNM7I9M3oNM4wdvJPwtyW5H8n+cmqeryq3jrddG3++tsFkuQ1\nSR6YTkv935K8vbX21CIHhkXTOKPTOCPTN6PTOHvBTs6+e91pjv/CKY7dnuT2+ceC1dE4o9M4I9M3\no9M4e8G8Z98FAACAXbOUAgAA0I2lFAAAgG4spQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABA\nN+f2HiBJvnXOs/nv5/1F7zH2jHsPHJjr8VfdddeCJlmsf/jJT/Ye4bQ0vjqj9p1onLH7Tta3cX2v\nhr770fhqaPz0vFIKAABAN5ZSAAAAurGUAgAA0M1a/E4pq7Xu70eHeeibkembkemb0Wn89CylDMP/\n6IxO44xO44xM34xunsartbbAUXY5RFX/IdgL7mut7e/xxBpnRTTO6Lo0rm9WxPdwRnfaxrf9ndKq\nuqSq/rCqvlBVn6+qX5qOP7+q7q6qh6eP50/Hq6o+UFWPVNUDVfWKxf63wGJpnNFpnJHpm9FpnL1g\nJyc6ejrJr7TWXpbkqiTvqKqXJbkxyT2ttcuT3DN9niRvSHL5dDmY5OaFTw2LpXFGp3FGpm9Gp3GG\nt+1S2lo71lr77HT9O0m+mOSiJNckuXW6261J3jhdvybJh9uWe5OcV1UXLnxyWBCNMzqNMzJ9MzqN\nsxec1T8JU1WXJvmpJJ9OckFr7dh009eTXDBdvyjJ12Ye9vh0DNaexhmdxhmZvhmdxhnVjs++W1U/\nnuT2JL/cWvt2Vf3gttZaO9tfkK6qg9l6SwGsBY0zOo0zMn0zOo0zsh29UlpVP5at/wl+u7X2u9Ph\nJ068FWD6+OR0/GiSS2YefvF07K9prR1qre3vdZYxmKVxRqdxRqZvRqdxRreTs+9Wkg8l+WJr7aaZ\nm+5Icv10/fokn5g5/pbpzF9XJfnWzFsLYO1onNFpnJHpm9FpnD2htXbGS5JXJWlJHkhy/3S5OskL\nsnWmr4eT/EGS50/3ryS/meTRJJ9Lsn8Hz9FcXFZwOaJxl8EvGncZ/fIjjUffLuNcfA93Gf1yysZb\na6kpxK7O9j3wsEv+UWpGp3FG16VxfbMivoczutM2flZn3wUAAIBFspQCAADQjaUUAACAbiylAAAA\ndHNu7wEm30hyfPq4qV4Y8/e0k/n/1ioGOQ2N97cX5u/Z+F8keajj889rL/Sx7ta5cd/D+9sL8/t7\nynz2QiPrbK7G1+Lsu0lSVUc2+R/vNX9fmzD/Jsx4Jubva93nX/f5tmP+/tb9v2Hd59uO+fvahPk3\nYcYzMX9f887v7bsAAAB0YykFAACgm3VaSg/1HmBO5u9rE+bfhBnPxPx9rfv86z7fdszf37r/N6z7\nfNsxf1+bMP8mzHgm5u9rrvnX5ndKAQAA2HvW6ZVSAAAA9hhLKQAAAN10X0qr6kBVPVRVj1TVjb3n\n2YmqeqyqPldV91fVkenY86vq7qp6ePp4fu85Z1XVLVX1ZFU9OHPslDPXlg9MfyYPVNUr+k3+g1lP\nNf97q+ro9Odwf1VdPXPbu6b5H6qqn+kz9Q9m0fiS6bsvjS+fxvvZxL4Tja+axldr0/pONL7tE7TW\nul2SnJPk0SQvSfKcJH+W5GU9Z9rh3I8leeFJx349yY3T9RuT/Ifec54032uSvCLJg9vNnOTqJL+f\npJJcleTTazr/e5P861Pc92VTS89NctnU2Dmd5tZ4vz70vZrZNd6vEY0vf+6N7HuaXeP959f48ube\nqL7P0IjGp0vvV0qvTPJIa+0rrbXvJ/lIkms6z7Rb1yS5dbp+a5I3dpzlR7TWPpXkqZMOn27ma5J8\nuG25N8l5VXXhaiY9tdPMfzrXJPlIa+17rbU/T/JItlrrQeMroO9ufScaXwmN+x6+IBpfEo2vhbXt\nO9F4tmm891J6UZKvzXz++HRs3bUkn6yq+6rq4HTsgtbasen615Nc0Ge0s3K6mTfpz+Wd09sabpl5\nm8Y6zb9Os5yNERrX92qs2zw7pfH1sO6Nr9MsZ0vj60HjyzFC34nGf6D3UrqpXtVae0WSNyR5R1W9\nZvbGtvW69Ub9WzubOHOSm5O8NMkVSY4leV/fcYYyVOObNu9E38ul8f40vlwa70/jyzNU38lmzpwF\nNt57KT2a5JKZzy+ejq211trR6eOTST6erZejnzjxsvr08cl+E+7Y6WbeiD+X1toTrbVnWmvPJvlg\nfvi2gHWaf51m2bFBGtf3aqzbPDui8f42pPF1muWsaLw/jS/PIH0nGv+B3kvpZ5JcXlWXVdVzklyb\n5I7OM51RVe2rqueduJ7k9UkezNbc1093uz7JJ/pMeFZON/MdSd4ynfnrqiTfmnlrwdo46b31b8rW\nn0OyNf+1VfXcqrosyeVJ/mTV80003o++V0Pj/Wh8+Tau70Tj60LjyzFQ34nGf+hMZ0FaxSVbZ5f6\ncrbOyvTu3vPsYN6XZOtsUn+W5PMnZk7ygiT3JHk4yR8keX7vWU+a+7Zsvaz+V9l6X/dbTzdzts70\n9ZvTn8nnkuxf0/n/yzTfA1P8F87c/93T/A8leUPn2TXepw99r25+jfdpROOrmX2j+p5m1vh6zK/x\n5cy7cX2foRGNT5eaHgQAAAAr1/vtuwAAAOxhllIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAA\noBtLKQAAAN38P4MFx8hKCA3KAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 1152x648 with 10 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "qkaEc5sRYr70"
-      },
-      "source": [
-        "**Let's play a little.**\n",
-        "\n",
-        "Pay attention to zoom and fps args of play function. Control: A, D, space."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ws7cnd9LYr72",
-        "colab": {}
-      },
-      "source": [
-        "# # does not work in colab.\n",
-        "# # make keyboard interrupt to continue\n",
-        "\n",
-        "# from gym.utils.play import play\n",
-        "\n",
-        "# play(env=gym.make(ENV_NAME), zoom=5, fps=30)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "T1aE7ZNiYr77"
-      },
-      "source": [
-        "### Processing game image \n",
-        "\n",
-        "Raw atari images are large, 210x160x3 by default. However, we don't need that level of detail in order to learn them.\n",
-        "\n",
-        "We can thus save a lot of time by preprocessing game image, including\n",
-        "* Resizing to a smaller shape, 64 x 64\n",
-        "* Converting to grayscale\n",
-        "* Cropping irrelevant image parts (top, bottom and edges)\n",
-        "\n",
-        "Also please keep one dimension for channel so that final shape would be 1 x 64 x 64.\n",
-        "\n",
-        "Tip: You can implement your own grayscale converter and assign a huge weight to the red channel. This dirty trick is not necessary but it will speed up learning."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "wAHF_w9gYr79",
-        "colab": {}
-      },
-      "source": [
-        "from gym.core import ObservationWrapper\n",
-        "from gym.spaces import Box\n",
-        "\n",
-        "\n",
-        "class PreprocessAtariObs(ObservationWrapper):\n",
-        "    def __init__(self, env):\n",
-        "        \"\"\"A gym wrapper that crops, scales image into the desired shapes and grayscales it.\"\"\"\n",
-        "        ObservationWrapper.__init__(self, env)\n",
-        "\n",
-        "        self.img_size = (1, 64, 64)\n",
-        "        self.observation_space = Box(0.0, 1.0, self.img_size)\n",
-        "\n",
-        "\n",
-        "    def _to_gray_scale(self, rgb, channel_weights=[0.8, 0.1, 0.1]):\n",
-        "        <Your code here>\n",
-        "\n",
-        "\n",
-        "    def observation(self, img):\n",
-        "        \"\"\"what happens to each observation\"\"\"\n",
-        "\n",
-        "        # Here's what you need to do:\n",
-        "        #  * crop image, remove irrelevant parts\n",
-        "        #  * resize image to self.img_size\n",
-        "        #     (use imresize from any library you want,\n",
-        "        #      e.g. opencv, skimage, PIL, keras)\n",
-        "        #  * cast image to grayscale\n",
-        "        #  * convert image pixels to (0,1) range, float32 type\n",
-        "        <Your code here>\n",
-        "        return < ... >"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "i2w_oLiHYr8C",
-        "colab": {}
-      },
-      "source": [
-        "import gym\n",
-        "# spawn game instance for tests\n",
-        "env = gym.make(ENV_NAME)  # create raw env\n",
-        "env = PreprocessAtariObs(env)\n",
-        "observation_shape = env.observation_space.shape\n",
-        "n_actions = env.action_space.n\n",
-        "env.reset()\n",
-        "obs, _, _, _ = env.step(env.action_space.sample())\n",
-        "\n",
-        "# test observation\n",
-        "assert obs.ndim == 3, \"observation must be [channel, h, w] even if there's just one channel\"\n",
-        "assert obs.shape == observation_shape\n",
-        "assert obs.dtype == 'float32'\n",
-        "assert len(np.unique(obs)) > 2, \"your image must not be binary\"\n",
-        "assert 0 <= np.min(obs) and np.max(\n",
-        "    obs) <= 1, \"convert image pixels to [0,1] range\"\n",
-        "\n",
-        "assert np.max(obs) >= 0.5, \"It would be easier to see a brighter observation\"\n",
-        "assert np.mean(obs) >= 0.1, \"It would be easier to see a brighter observation\"\n",
-        "\n",
-        "print(\"Formal tests seem fine. Here's an example of what you'll get.\")\n",
-        "\n",
-        "n_cols = 5\n",
-        "n_rows = 2\n",
-        "fig = plt.figure(figsize=(16, 9))\n",
-        "obs = env.reset()\n",
-        "for row in range(n_rows):\n",
-        "    for col in range(n_cols):\n",
-        "        ax = fig.add_subplot(n_rows, n_cols, row * n_cols + col + 1)\n",
-        "        ax.imshow(obs[0, :, :], interpolation='none', cmap='gray')\n",
-        "        obs, _, _, _ = env.step(env.action_space.sample())\n",
-        "plt.show()\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "jg7LfazSYr8I"
-      },
-      "source": [
-        "### Wrapping."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "pFlWGGJ7Yr8K"
-      },
-      "source": [
-        "**About the game:** You have 5 lives and get points for breaking the wall. Higher bricks cost more than the lower ones. There are 4 actions: start game (should be called at the beginning and after each life is lost), move left, move right and do nothing. There are some common wrappers used for Atari environments."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "BkMmgtwJYr8M",
-        "colab": {}
-      },
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2\n",
-        "import atari_wrappers\n",
-        "\n",
-        "def PrimaryAtariWrap(env, clip_rewards=True):\n",
-        "    assert 'NoFrameskip' in env.spec.id\n",
-        "\n",
-        "    # This wrapper holds the same action for <skip> frames and outputs\n",
-        "    # the maximal pixel value of 2 last frames (to handle blinking\n",
-        "    # in some envs)\n",
-        "    env = atari_wrappers.MaxAndSkipEnv(env, skip=4)\n",
-        "\n",
-        "    # This wrapper sends done=True when each life is lost\n",
-        "    # (not all the 5 lives that are givern by the game rules).\n",
-        "    # It should make easier for the agent to understand that losing is bad.\n",
-        "    env = atari_wrappers.EpisodicLifeEnv(env)\n",
-        "\n",
-        "    # This wrapper laucnhes the ball when an episode starts.\n",
-        "    # Without it the agent has to learn this action, too.\n",
-        "    # Actually it can but learning would take longer.\n",
-        "    env = atari_wrappers.FireResetEnv(env)\n",
-        "\n",
-        "    # This wrapper transforms rewards to {-1, 0, 1} according to their sign\n",
-        "    if clip_rewards:\n",
-        "        env = atari_wrappers.ClipRewardEnv(env)\n",
-        "\n",
-        "    # This wrapper is yours :)\n",
-        "    env = PreprocessAtariObs(env)\n",
-        "    return env"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "3J9JAvgPYr8Q"
-      },
-      "source": [
-        "**Let's see if the game is still playable after applying the wrappers.**\n",
-        "At playing the EpisodicLifeEnv wrapper seems not to work but actually it does (because after when life finishes a new ball is dropped automatically - it means that FireResetEnv wrapper understands that a new episode began)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "KVkGPGa5Yr8S",
-        "colab": {}
-      },
-      "source": [
-        "# # does not work in colab.\n",
-        "# # make keyboard interrupt to continue\n",
-        "\n",
-        "# from gym.utils.play import play\n",
-        "\n",
-        "# def make_play_env():\n",
-        "#     env = gym.make(ENV_NAME)\n",
-        "#     env = PrimaryAtariWrap(env)\n",
-        "# # in torch imgs have shape [c, h, w] instead of common [h, w, c]\n",
-        "#     env = atari_wrappers.AntiTorchWrapper(env)\n",
-        "#     return env\n",
-        "\n",
-        "# play(make_play_env(), zoom=10, fps=3)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "tqhgqtTFYr8X"
-      },
-      "source": [
-        "### Frame buffer\n",
-        "\n",
-        "Our agent can only process one observation at a time, so we gotta make sure it contains enough information to find optimal actions. For instance, agent has to react to moving objects so he must be able to measure object's velocity.\n",
-        "\n",
-        "To do so, we introduce a buffer that stores 4 last images. This time everything is pre-implemented for you, not really by the staff of the course :)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "1NFYjOW8Yr8Y",
-        "colab": {}
-      },
-      "source": [
-        "from framebuffer import FrameBuffer\n",
-        "\n",
-        "def make_env(clip_rewards=True, seed=None):\n",
-        "    env = gym.make(ENV_NAME)  # create raw env\n",
-        "    if seed is not None:\n",
-        "        env.seed(seed)\n",
-        "    env = PrimaryAtariWrap(env, clip_rewards)\n",
-        "    env = FrameBuffer(env, n_frames=4, dim_order='pytorch')\n",
-        "    return env\n",
-        "\n",
-        "env = make_env()\n",
-        "env.reset()\n",
-        "n_actions = env.action_space.n\n",
-        "state_shape = env.observation_space.shape"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ETuq6BDrYr8f",
-        "colab": {}
-      },
-      "source": [
-        "for _ in range(12):\n",
-        "    obs, _, _, _ = env.step(env.action_space.sample())\n",
-        "\n",
-        "plt.figure(figsize=[12,10])\n",
-        "plt.title(\"Game image\")\n",
-        "plt.imshow(env.render(\"rgb_array\"))\n",
-        "plt.show()\n",
-        "\n",
-        "plt.figure(figsize=[15,15])\n",
-        "plt.title(\"Agent observation (4 frames top to bottom)\")\n",
-        "plt.imshow(utils.img_by_obs(obs, state_shape), cmap='gray')\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "g9jQvmKdYr8l"
-      },
-      "source": [
-        "## DQN as it is (4 pts)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "H6UK0OU0Yr8m"
-      },
-      "source": [
-        "### Building a network\n",
-        "\n",
-        "We now need to build a neural network that can map images to state q-values. This network will be called on every agent's step so it better not be resnet-152 unless you have an array of GPUs. Instead, you can use strided convolutions with a small number of features to save time and memory.\n",
-        "\n",
-        "You can build any architecture you want, but for reference, here's something that will more or less work:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "L9gs_ZucYr8o"
-      },
-      "source": [
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/dqn_arch.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KaQpcmSKm29I",
-        "colab_type": "text"
-      },
-      "source": [
-        "**Dueling network: (+2 pts)**\n",
-        "$$Q_{\\theta}(s, a) = V_{\\eta}(f_{\\xi}(s)) + A_{\\psi}(f_{\\xi}(s), a) - \\frac{\\sum_{a'}A_{\\psi}(f_{\\xi}(s), a')}{N_{actions}},$$\n",
-        "where $\\xi$, $\\eta$, and $\\psi$ are, respectively, the parameters of the\n",
-        "shared encoder $f_ξ$ , of the value stream $V_\\eta$ , and of the advan\n",
-        "tage stream $A_\\psi$; and $\\theta = \\{\\xi, \\eta, \\psi\\}$ is their concatenation.\n",
-        "\n",
-        "For the architecture on the image $V$ and $A$ heads can follow the dense layer instead of $Q$. Please don't worry that the model becomes a little bigger."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "p9EaBWcbYr8p",
-        "colab": {}
-      },
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-        "# those who have a GPU but feel unfair to use it can uncomment:\n",
-        "# device = torch.device('cpu')\n",
-        "device"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "AWBLdSxAYr8t",
-        "colab": {}
-      },
-      "source": [
-        "def conv2d_size_out(size, kernel_size, stride):\n",
-        "    \"\"\"\n",
-        "    common use case:\n",
-        "    cur_layer_img_w = conv2d_size_out(cur_layer_img_w, kernel_size, stride)\n",
-        "    cur_layer_img_h = conv2d_size_out(cur_layer_img_h, kernel_size, stride)\n",
-        "    to understand the shape for dense layer's input\n",
-        "    \"\"\"\n",
-        "    return (size - (kernel_size - 1) - 1) // stride  + 1\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "xAYejeRuYr8y",
-        "colab": {}
-      },
-      "source": [
-        "class DQNAgent(nn.Module):\n",
-        "    def __init__(self, state_shape, n_actions, epsilon=0):\n",
-        "\n",
-        "        super().__init__()\n",
-        "        self.epsilon = epsilon\n",
-        "        self.n_actions = n_actions\n",
-        "        self.state_shape = state_shape\n",
-        "\n",
-        "        # Define your network body here. Please make sure agent is fully contained here\n",
-        "        # nn.Flatten() can be useful\n",
-        "        <YOUR CODE>\n",
-        "        \n",
-        "\n",
-        "    def forward(self, state_t):\n",
-        "        \"\"\"\n",
-        "        takes agent's observation (tensor), returns qvalues (tensor)\n",
-        "        :param state_t: a batch of 4-frame buffers, shape = [batch_size, 4, h, w]\n",
-        "        \"\"\"\n",
-        "        # Use your network to compute qvalues for given state\n",
-        "        qvalues = <YOUR CODE>\n",
-        "\n",
-        "        assert qvalues.requires_grad, \"qvalues must be a torch tensor with grad\"\n",
-        "        assert len(\n",
-        "            qvalues.shape) == 2 and qvalues.shape[0] == state_t.shape[0] and qvalues.shape[1] == n_actions\n",
-        "\n",
-        "        return qvalues\n",
-        "\n",
-        "    def get_qvalues(self, states):\n",
-        "        \"\"\"\n",
-        "        like forward, but works on numpy arrays, not tensors\n",
-        "        \"\"\"\n",
-        "        model_device = next(self.parameters()).device\n",
-        "        states = torch.tensor(states, device=model_device, dtype=torch.float)\n",
-        "        qvalues = self.forward(states)\n",
-        "        return qvalues.data.cpu().numpy()\n",
-        "\n",
-        "    def sample_actions(self, qvalues):\n",
-        "        \"\"\"pick actions given qvalues. Uses epsilon-greedy exploration strategy. \"\"\"\n",
-        "        epsilon = self.epsilon\n",
-        "        batch_size, n_actions = qvalues.shape\n",
-        "\n",
-        "        random_actions = np.random.choice(n_actions, size=batch_size)\n",
-        "        best_actions = qvalues.argmax(axis=-1)\n",
-        "\n",
-        "        should_explore = np.random.choice(\n",
-        "            [0, 1], batch_size, p=[1-epsilon, epsilon])\n",
-        "        return np.where(should_explore, random_actions, best_actions)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ScWX-Jh5Yr83",
-        "colab": {}
-      },
-      "source": [
-        "agent = DQNAgent(state_shape, n_actions, epsilon=0.5).to(device)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "dtvIPzsvYr8-"
-      },
-      "source": [
-        "Now let's try out our agent to see if it raises any errors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "zSfjyA61Yr8_",
-        "colab": {}
-      },
-      "source": [
-        "def evaluate(env, agent, n_games=1, greedy=False, t_max=10000):\n",
-        "    \"\"\" Plays n_games full games. If greedy, picks actions as argmax(qvalues). Returns mean reward. \"\"\"\n",
-        "    rewards = []\n",
-        "    for _ in range(n_games):\n",
-        "        s = env.reset()\n",
-        "        reward = 0\n",
-        "        for _ in range(t_max):\n",
-        "            qvalues = agent.get_qvalues([s])\n",
-        "            action = qvalues.argmax(axis=-1)[0] if greedy else agent.sample_actions(qvalues)[0]\n",
-        "            s, r, done, _ = env.step(action)\n",
-        "            reward += r\n",
-        "            if done:\n",
-        "                break\n",
-        "\n",
-        "        rewards.append(reward)\n",
-        "    return np.mean(rewards)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "VOqq0s-dYr9E",
-        "colab": {}
-      },
-      "source": [
-        "evaluate(env, agent, n_games=1)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "PbvsEbQCYr9I"
-      },
-      "source": [
-        "### Experience replay\n",
-        "For this assignment, we provide you with experience replay buffer. If you implemented experience replay buffer in last week's assignment, you can copy-paste it here **to get 2 bonus points**.\n",
-        "\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/exp_replay.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "b-7hvrmlYr9J"
-      },
-      "source": [
-        "#### The interface is fairly simple:\n",
-        "* `exp_replay.add(obs, act, rw, next_obs, done)` - saves (s,a,r,s',done) tuple into the buffer\n",
-        "* `exp_replay.sample(batch_size)` - returns observations, actions, rewards, next_observations and is_done for `batch_size` random samples.\n",
-        "* `len(exp_replay)` - returns number of elements stored in replay buffer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "SCxjXMh_Yr9L",
-        "colab": {}
-      },
-      "source": [
-        "from replay_buffer import ReplayBuffer\n",
-        "exp_replay = ReplayBuffer(10)\n",
-        "\n",
-        "for _ in range(30):\n",
-        "    exp_replay.add(env.reset(), env.action_space.sample(),\n",
-        "                   1.0, env.reset(), done=False)\n",
-        "\n",
-        "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "    5)\n",
-        "\n",
-        "assert len(exp_replay) == 10, \"experience replay size should be 10 because that's what maximum capacity is\""
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "U2wht2xzYr9P",
-        "colab": {}
-      },
-      "source": [
-        "def play_and_record(initial_state, agent, env, exp_replay, n_steps=1):\n",
-        "    \"\"\"\n",
-        "    Play the game for exactly n steps, record every (s,a,r,s', done) to replay buffer. \n",
-        "    Whenever game ends, add record with done=True and reset the game.\n",
-        "    It is guaranteed that env has done=False when passed to this function.\n",
-        "\n",
-        "    PLEASE DO NOT RESET ENV UNLESS IT IS \"DONE\"\n",
-        "\n",
-        "    :returns: return sum of rewards over time and the state in which the env stays\n",
-        "    \"\"\"\n",
-        "    s = initial_state\n",
-        "    sum_rewards = 0\n",
-        "\n",
-        "    # Play the game for n_steps as per instructions above\n",
-        "    <YOUR CODE >\n",
-        "\n",
-        "    return sum_rewards, s"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "B176fzI-Yr9T",
-        "colab": {}
-      },
-      "source": [
-        "# testing your code.\n",
-        "exp_replay = ReplayBuffer(2000)\n",
-        "\n",
-        "state = env.reset()\n",
-        "play_and_record(state, agent, env, exp_replay, n_steps=1000)\n",
-        "\n",
-        "# if you're using your own experience replay buffer, some of those tests may need correction.\n",
-        "# just make sure you know what your code does\n",
-        "assert len(exp_replay) == 1000, \"play_and_record should have added exactly 1000 steps, \"\\\n",
-        "                                 \"but instead added %i\" % len(exp_replay)\n",
-        "is_dones = list(zip(*exp_replay._storage))[-1]\n",
-        "\n",
-        "assert 0 < np.mean(is_dones) < 0.1, \"Please make sure you restart the game whenever it is 'done' and record the is_done correctly into the buffer.\"\\\n",
-        "                                    \"Got %f is_done rate over %i steps. [If you think it's your tough luck, just re-run the test]\" % (\n",
-        "                                        np.mean(is_dones), len(exp_replay))\n",
-        "\n",
-        "for _ in range(100):\n",
-        "    obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "        10)\n",
-        "    assert obs_batch.shape == next_obs_batch.shape == (10,) + state_shape\n",
-        "    assert act_batch.shape == (\n",
-        "        10,), \"actions batch should have shape (10,) but is instead %s\" % str(act_batch.shape)\n",
-        "    assert reward_batch.shape == (\n",
-        "        10,), \"rewards batch should have shape (10,) but is instead %s\" % str(reward_batch.shape)\n",
-        "    assert is_done_batch.shape == (\n",
-        "        10,), \"is_done batch should have shape (10,) but is instead %s\" % str(is_done_batch.shape)\n",
-        "    assert [int(i) in (0, 1)\n",
-        "            for i in is_dones], \"is_done should be strictly True or False\"\n",
-        "    assert [\n",
-        "        0 <= a < n_actions for a in act_batch], \"actions should be within [0, n_actions)\"\n",
-        "\n",
-        "print(\"Well done!\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "NaaAuU6IYr9Z"
-      },
-      "source": [
-        "### Target networks\n",
-        "\n",
-        "We also employ the so called \"target network\" - a copy of neural network weights to be used for reference Q-values:\n",
-        "\n",
-        "The network itself is an exact copy of agent network, but it's parameters are not trained. Instead, they are moved here from agent's actual network every so often.\n",
-        "\n",
-        "$$ Q_{reference}(s,a) = r + \\gamma \\cdot \\max _{a'} Q_{target}(s',a') $$\n",
-        "\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/target_net.png)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "rxFt9aHtYr9a",
-        "colab": {}
-      },
-      "source": [
-        "target_network = DQNAgent(agent.state_shape, agent.n_actions, epsilon=0.5).to(device)\n",
-        "# This is how you can load weights from agent into target network\n",
-        "target_network.load_state_dict(agent.state_dict())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "v4Oom6q6Yr9e"
-      },
-      "source": [
-        "### Learning with... Q-learning\n",
-        "Here we write a function similar to `agent.update` from tabular q-learning."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "sMuDQMH0Yr9g"
-      },
-      "source": [
-        "Compute Q-learning TD error:\n",
-        "\n",
-        "$$ L = { 1 \\over N} \\sum_i [ Q_{\\theta}(s,a) - Q_{reference}(s,a) ] ^2 $$\n",
-        "\n",
-        "With Q-reference defined as\n",
-        "\n",
-        "$$ Q_{reference}(s,a) = r(s,a) + \\gamma \\cdot max_{a'} Q_{target}(s', a') $$\n",
-        "\n",
-        "Where\n",
-        "* $Q_{target}(s',a')$ denotes q-value of next state and next action predicted by __target_network__\n",
-        "* $s, a, r, s'$ are current state, action, reward and next state respectively\n",
-        "* $\\gamma$ is a discount factor defined two cells above.\n",
-        "\n",
-        "\n",
-        "__Note 1:__ there's an example input below. Feel free to experiment with it before you write the function.\n",
-        "\n",
-        "__Note 2:__ compute_td_loss is a source of 99% of bugs in this homework. If reward doesn't improve, it often helps to go through it line by line [with a rubber duck](https://rubberduckdebugging.com/).\n",
-        "\n",
-        "**Double DQN (+2 pts)**\n",
-        "\n",
-        "$$ Q_{reference}(s,a) = r(s, a) + \\gamma \\cdot\n",
-        "Q_{target}(s',argmax_{a'}Q_\\theta(s', a')) $$"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "pw28IOoNYr9h",
-        "colab": {}
-      },
-      "source": [
-        "def compute_td_loss(states, actions, rewards, next_states, is_done,\n",
-        "                    agent, target_network,\n",
-        "                    gamma=0.99,\n",
-        "                    check_shapes=False,\n",
-        "                    device=device):\n",
-        "    \"\"\" Compute td loss using torch operations only. Use the formulae above. \"\"\"\n",
-        "    states = torch.tensor(states, device=device, dtype=torch.float)    # shape: [batch_size, *state_shape]\n",
-        "\n",
-        "    # for some torch reason should not make actions a tensor\n",
-        "    actions = torch.tensor(actions, device=device, dtype=torch.long)    # shape: [batch_size]\n",
-        "    rewards = torch.tensor(rewards, device=device, dtype=torch.float)  # shape: [batch_size]\n",
-        "    # shape: [batch_size, *state_shape]\n",
-        "    next_states = torch.tensor(next_states, device=device, dtype=torch.float)\n",
-        "    is_done = torch.tensor(\n",
-        "        is_done.astype('float32'),\n",
-        "        device=device,\n",
-        "        dtype=torch.float\n",
-        "    )  # shape: [batch_size]\n",
-        "    is_not_done = 1 - is_done\n",
-        "\n",
-        "    # get q-values for all actions in current states\n",
-        "    predicted_qvalues = agent(states)\n",
-        "\n",
-        "    # compute q-values for all actions in next states\n",
-        "    predicted_next_qvalues = target_network(next_states)\n",
-        "    \n",
-        "    # select q-values for chosen actions\n",
-        "    predicted_qvalues_for_actions = predicted_qvalues[range(\n",
-        "        len(actions)), actions]\n",
-        "\n",
-        "    # compute V*(next_states) using predicted next q-values\n",
-        "    next_state_values = <YOUR CODE>\n",
-        "\n",
-        "    assert next_state_values.dim(\n",
-        "    ) == 1 and next_state_values.shape[0] == states.shape[0], \"must predict one value per state\"\n",
-        "\n",
-        "    # compute \"target q-values\" for loss - it's what's inside square parentheses in the above formula.\n",
-        "    # at the last state use the simplified formula: Q(s,a) = r(s,a) since s' doesn't exist\n",
-        "    # you can multiply next state values by is_not_done to achieve this.\n",
-        "    target_qvalues_for_actions = <YOUR CODE>\n",
-        "\n",
-        "    # mean squared error loss to minimize\n",
-        "    loss = torch.mean((predicted_qvalues_for_actions -\n",
-        "                       target_qvalues_for_actions.detach()) ** 2)\n",
-        "\n",
-        "    if check_shapes:\n",
-        "        assert predicted_next_qvalues.data.dim(\n",
-        "        ) == 2, \"make sure you predicted q-values for all actions in next state\"\n",
-        "        assert next_state_values.data.dim(\n",
-        "        ) == 1, \"make sure you computed V(s') as maximum over just the actions axis and not all axes\"\n",
-        "        assert target_qvalues_for_actions.data.dim(\n",
-        "        ) == 1, \"there's something wrong with target q-values, they must be a vector\"\n",
-        "\n",
-        "    return loss"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "vKWfaNgIYr9n"
-      },
-      "source": [
-        "Sanity checks"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "x79qZpdhYr9o",
-        "colab": {}
-      },
-      "source": [
-        "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
-        "    10)\n",
-        "\n",
-        "loss = compute_td_loss(obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch,\n",
-        "                       agent, target_network,\n",
-        "                       gamma=0.99, check_shapes=True)\n",
-        "loss.backward()\n",
-        "\n",
-        "assert loss.requires_grad and tuple(loss.data.size()) == (\n",
-        "    ), \"you must return scalar loss - mean over batch\"\n",
-        "assert np.any(next(agent.parameters()).grad.data.cpu().numpy() !=\n",
-        "              0), \"loss must be differentiable w.r.t. network weights\"\n",
-        "assert np.all(next(target_network.parameters()).grad is None), \"target network should not have grads\""
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "NCFDmvDRYr9s"
-      },
-      "source": [
-        "## Main loop (3 pts)\n",
-        "\n",
-        "**If deadline is tonight and it has not converged:** It is ok. Send the notebook today and when it converges send it again.\n",
-        "If the code is exactly the same points will not be discounted.\n",
-        "\n",
-        "It's time to put everything together and see if it learns anything."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "j3TTjorrYr9u",
-        "colab": {}
-      },
-      "source": [
-        "from tqdm import trange\n",
-        "from IPython.display import clear_output\n",
-        "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "RNXm6ky-Yr9y",
-        "colab": {}
-      },
-      "source": [
-        "seed = <your favourite random seed>\n",
-        "random.seed(seed)\n",
-        "np.random.seed(seed)\n",
-        "torch.manual_seed(seed)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "ZLtZg0PNYr92",
-        "colab": {}
-      },
-      "source": [
-        "env = make_env(seed)\n",
-        "state_shape = env.observation_space.shape\n",
-        "n_actions = env.action_space.n\n",
-        "state = env.reset()\n",
-        "\n",
-        "agent = DQNAgent(state_shape, n_actions, epsilon=1).to(device)\n",
-        "target_network = DQNAgent(state_shape, n_actions).to(device)\n",
-        "target_network.load_state_dict(agent.state_dict())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "SJBhKbCLYr96"
-      },
-      "source": [
-        "Buffer of size $10^4$ fits into 5 Gb RAM.\n",
-        "\n",
-        "Larger sizes ($10^5$ and $10^6$ are common) can be used. It can improve the learning, but $10^4$ is quiet enough. $10^2$ will probably fail learning."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "vj9Yfv5oYr97",
-        "colab": {}
-      },
-      "source": [
-        "exp_replay = ReplayBuffer(10**4)\n",
-        "for i in range(100):\n",
-        "    if not utils.is_enough_ram(min_available_gb=0.1):\n",
-        "        print(\"\"\"\n",
-        "            Less than 100 Mb RAM available. \n",
-        "            Make sure the buffer size in not too huge.\n",
-        "            Also check, maybe other processes consume RAM heavily.\n",
-        "            \"\"\"\n",
-        "             )\n",
-        "        break\n",
-        "    play_and_record(state, agent, env, exp_replay, n_steps=10**2)\n",
-        "    if len(exp_replay) == 10**4:\n",
-        "        break\n",
-        "print(len(exp_replay))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "zu2ADfFUYr-A",
-        "colab": {}
-      },
-      "source": [
-        "timesteps_per_epoch = 1\n",
-        "batch_size = 16\n",
-        "total_steps = 3 * 10**6\n",
-        "decay_steps = 10**6\n",
-        "\n",
-        "opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
-        "\n",
-        "init_epsilon = 1\n",
-        "final_epsilon = 0.1\n",
-        "\n",
-        "loss_freq = 50\n",
-        "refresh_target_network_freq = 5000\n",
-        "eval_freq = 5000\n",
-        "\n",
-        "max_grad_norm = 50\n",
-        "\n",
-        "n_lives = 5"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "24qZh-6YYr-E",
-        "colab": {}
-      },
-      "source": [
-        "mean_rw_history = []\n",
-        "td_loss_history = []\n",
-        "grad_norm_history = []\n",
-        "initial_state_v_history = []\n",
-        "step = 0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "BzsBPAzcYr-K",
-        "colab": {}
-      },
-      "source": [
-        "state = env.reset()\n",
-        "for step in trange(step, total_steps + 1):\n",
-        "    if not utils.is_enough_ram():\n",
-        "        print('less that 100 Mb RAM available, freezing')\n",
-        "        print('make sure everythin is ok and make KeyboardInterrupt to continue')\n",
-        "        try:\n",
-        "            while True:\n",
-        "                pass\n",
-        "        except KeyboardInterrupt:\n",
-        "            pass\n",
-        "\n",
-        "    agent.epsilon = utils.linear_decay(init_epsilon, final_epsilon, step, decay_steps)\n",
-        "\n",
-        "    # play\n",
-        "    _, state = play_and_record(state, agent, env, exp_replay, timesteps_per_epoch)\n",
-        "\n",
-        "    # train\n",
-        "    < sample batch_size of data from experience replay >\n",
-        "\n",
-        "    loss = < compute TD loss >\n",
-        "\n",
-        "    loss.backward()\n",
-        "    grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), max_grad_norm)\n",
-        "    opt.step()\n",
-        "    opt.zero_grad()\n",
-        "\n",
-        "    if step % loss_freq == 0:\n",
-        "        td_loss_history.append(loss.data.cpu().item())\n",
-        "        grad_norm_history.append(grad_norm)\n",
-        "\n",
-        "    if step % refresh_target_network_freq == 0:\n",
-        "        # Load agent weights into target_network\n",
-        "        <YOUR CODE >\n",
-        "\n",
-        "    if step % eval_freq == 0:\n",
-        "        mean_rw_history.append(evaluate(\n",
-        "            make_env(clip_rewards=True, seed=step), agent, n_games=3 * n_lives, greedy=True)\n",
-        "        )\n",
-        "        initial_state_q_values = agent.get_qvalues(\n",
-        "            [make_env(seed=step).reset()]\n",
-        "        )\n",
-        "        initial_state_v_history.append(np.max(initial_state_q_values))\n",
-        "\n",
-        "        clear_output(True)\n",
-        "        print(\"buffer size = %i, epsilon = %.5f\" %\n",
-        "              (len(exp_replay), agent.epsilon))\n",
-        "\n",
-        "        plt.figure(figsize=[16, 9])\n",
-        "\n",
-        "        plt.subplot(2, 2, 1)\n",
-        "        plt.title(\"Mean reward per life\")\n",
-        "        plt.plot(mean_rw_history)\n",
-        "        plt.grid()\n",
-        "\n",
-        "        assert not np.isnan(td_loss_history[-1])\n",
-        "        plt.subplot(2, 2, 2)\n",
-        "        plt.title(\"TD loss history (smoothened)\")\n",
-        "        plt.plot(utils.smoothen(td_loss_history))\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.subplot(2, 2, 3)\n",
-        "        plt.title(\"Initial state V\")\n",
-        "        plt.plot(initial_state_v_history)\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.subplot(2, 2, 4)\n",
-        "        plt.title(\"Grad norm history (smoothened)\")\n",
-        "        plt.plot(utils.smoothen(grad_norm_history))\n",
-        "        plt.grid()\n",
-        "\n",
-        "        plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "hiy8gc2ZYr-N"
-      },
-      "source": [
-        "Agent is evaluated for 1 life, not for a whole episode of 5 lives. Rewards in evaluation are also truncated. Cuz this is what environment the agent is learning in and in this way mean rewards per life can be compared with initial state value\n",
-        "\n",
-        "**The goal is to get 15 points in the real env**. So 3 or better 4 points in the preprocessed one will probably be enough. You can interrupt learning then."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "2b8ee9PXYr-O"
-      },
-      "source": [
-        "Final scoring is done on a whole episode with all 5 lives."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "w12Lx_lfYr-P",
-        "colab": {}
-      },
-      "source": [
-        "final_score = evaluate(\n",
-        "  make_env(clip_rewards=False, seed=9),\n",
-        "    agent, n_games=30, greedy=True, t_max=10 * 1000\n",
-        ") * n_lives\n",
-        "print('final score:', final_score)\n",
-        "assert final_score >= 15, 'not as cool as DQN can'\n",
-        "print('Cool!')"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "JmCIqQteYr-T"
-      },
-      "source": [
-        "## How to interpret plots:\n",
-        "\n",
-        "This aint no supervised learning so don't expect anything to improve monotonously. \n",
-        "* **TD loss** is the MSE between agent's current Q-values and target Q-values. It may slowly increase or decrease, it's ok. The \"not ok\" behavior includes going NaN or stayng at exactly zero before agent has perfect performance.\n",
-        "* **grad norm** just shows the intensivity of training. Not ok is growing to values of about 100 (or maybe even 50) though it depends on network architecture.\n",
-        "* **mean reward** is the expected sum of r(s,a) agent gets over the full game session. It will oscillate, but on average it should get higher over time (after a few thousand iterations...). \n",
-        " * In basic q-learning implementation it takes about 40k steps to \"warm up\" agent before it starts to get better.\n",
-        "* **Initial state V** is the expected discounted reward for episode in the oppinion of the agent. It should behave more smoothly than **mean reward**. It should get higher over time but sometimes can experience drawdowns because of the agaent's overestimates.\n",
-        "* **buffer size** - this one is simple. It should go up and cap at max size.\n",
-        "* **epsilon** - agent's willingness to explore. If you see that agent's already at 0.01 epsilon before it's average reward is above 0 - it means you need to increase epsilon. Set it back to some 0.2 - 0.5 and decrease the pace at which it goes down.\n",
-        "* Smoothing of plots is done with a gaussian kernel\n",
-        "\n",
-        "At first your agent will lose quickly. Then it will learn to suck less and at least hit the ball a few times before it loses. Finally it will learn to actually score points.\n",
-        "\n",
-        "**Training will take time.** A lot of it actually. Probably you will not see any improvment during first **150k** time steps (note that by default in this notebook agent is evaluated every 5000 time steps).\n",
-        "\n",
-        "But hey, long training time isn't _that_ bad:\n",
-        "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/training.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "7rf-ATYqYr-U"
-      },
-      "source": [
-        "## About hyperparameters:\n",
-        "\n",
-        "The task has something in common with supervised learning: loss is optimized through the buffer (instead of Train dataset). But the distribution of states and actions in the buffer **is not stationary** and depends on the policy that generated it. It can even happen that the mean TD error across the buffer is very low but the performance is extremely poor (imagine the agent collecting data to the buffer always manages to avoid the ball).\n",
-        "\n",
-        "* Total timesteps and training time: It seems to be so huge, but actually it is normal for RL.\n",
-        "\n",
-        "* $\\epsilon$ decay shedule was taken from the original paper and is like traditional for epsilon-greedy policies. At the beginning of the training the agent's greedy policy is poor so many random actions should be taken.\n",
-        "\n",
-        "* Optimizer: In the original paper RMSProp was used (they did not have Adam in 2013) and it can work not worse than Adam. For us Adam was default and it worked.\n",
-        "\n",
-        "* lr: $10^{-3}$ would probably be too huge\n",
-        "\n",
-        "* batch size: This one can be very important: if it is too small the agent can fail to learn. Huge batch takes more time to process. If batch of size 8 can not be processed on the hardware you use take 2 (or even 4) batches of size 4, divide the loss on them by 2 (or 4) and make optimization step after both backward() calls in torch.\n",
-        "\n",
-        "* target network update frequency: has something in common with learning rate. Too frequent updates can lead to divergence. Too rare can lead to slow leraning. For millions of total timesteps thousands of inner steps seem ok. One iteration of target network updating is an iteration of the (this time approximate) $\\gamma$-compression that stands behind Q-learning. The more inner steps it makes the more accurate is the compression.\n",
-        "* max_grad_norm - just huge enough. In torch clip_grad_norm also evaluates the norm before clipping and it can be convenient for logging."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "mw1NpGggYr-V"
-      },
-      "source": [
-        "### Video"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "Up05RZ8uYr-Y",
-        "colab": {}
-      },
-      "source": [
-        "# record sessions\n",
-        "import gym.wrappers\n",
-        "env_monitor = gym.wrappers.Monitor(make_env(), directory=\"videos\", force=True)\n",
-        "sessions = [evaluate(env_monitor, agent, n_games=n_lives, greedy=True) for _ in range(10)]\n",
-        "env_monitor.close()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "OLKEuSu9Yr-f",
-        "colab": {}
-      },
-      "source": [
-        "# show video\n",
-        "from IPython.display import HTML\n",
-        "import os\n",
-        "\n",
-        "video_names = list(\n",
-        "    filter(lambda s: s.endswith(\".mp4\"), os.listdir(\"./videos/\")))\n",
-        "\n",
-        "HTML(\"\"\"\n",
-        "<video width=\"640\" height=\"480\" controls>\n",
-        "  <source src=\"{}\" type=\"video/mp4\">\n",
-        "</video>\n",
-        "\"\"\".format(\"./videos/\"+video_names[-1]))  # this may or may not be _last_ video. Try other indices"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "QWCbJUK-Yr-k"
-      },
-      "source": [
-        "## Let's have a closer look at this.\n",
-        "\n",
-        "If average episode score is below 200 using all 5 lives, then probably DQN has not converged fully. But anyway let's make a more complete record of an episode."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "MNPOJAZTYr-l",
-        "colab": {}
-      },
-      "source": [
-        "eval_env = make_env(clip_rewards=False)\n",
-        "record = utils.play_and_log_episode(eval_env, agent)\n",
-        "print('total reward for life:', np.sum(record['rewards']))\n",
-        "for key in record:\n",
-        "    print(key)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "aW8vnU_IYr-r",
-        "colab": {}
-      },
-      "source": [
-        "fig = plt.figure(figsize=(5, 5))\n",
-        "ax = fig.add_subplot(1, 1, 1)\n",
-        "\n",
-        "ax.scatter(record['v_mc'], record['v_agent'])\n",
-        "ax.plot(sorted(record['v_mc']), sorted(record['v_mc']),\n",
-        "       'black', linestyle='--', label='x=y')\n",
-        "\n",
-        "ax.grid()\n",
-        "ax.legend()\n",
-        "ax.set_title('State Value Estimates')\n",
-        "ax.set_xlabel('Monte-Carlo')\n",
-        "ax.set_ylabel('Agent')\n",
-        "\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "5VT1N3MpYr-x"
-      },
-      "source": [
-        "$\\hat V_{Monte-Carlo}(s_t) = \\sum_{\\tau=0}^{episode~end} \\gamma^{\\tau-t}r_t$"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "u9GWlVC-Yr-z"
-      },
-      "source": [
-        "Is there a big bias? It's ok, anyway it works."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "hYHBYISWYr-1"
-      },
-      "source": [
-        "## Bonus I (2 pts)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "h4Qzhel-Yr-2"
-      },
-      "source": [
-        "**1.** Plot several (say 3) states with high and low spreads of Q estimate by actions i.e.\n",
-        "$$\\max_a \\hat Q(s,a) - \\min_a \\hat Q(s,a)\\$$\n",
-        "Please take those states from different episodes to make sure that the states are really different.\n",
-        "\n",
-        "What should high and low spread mean at least in the world of perfect Q-fucntions?\n",
-        "\n",
-        "Comment the states you like most.\n",
-        "\n",
-        "**2.** Plot several (say 3) states with high td-error and several states with high values of\n",
-        "$$| \\hat V_{Monte-Carlo}(s) - \\hat V_{agent}(s)|,$$ \n",
-        "$$\\hat V_{agent}(s)=\\max_a \\hat Q(s,a).$$ Please take those states from different episodes to make sure that the states are really different. From what part (i.e. beginning, middle, end) of an episode did these states come from?\n",
-        "\n",
-        "Comment the states you like most."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "blY7EK_MYr-3",
-        "colab": {}
-      },
-      "source": [
-        "from utils import play_and_log_episode, img_by_obs\n",
-        "\n",
-        "<YOUR CODE>"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ns-dIW66Yr-7"
-      },
-      "source": [
-        "## Bonus II (1-5 pts). Get High Score!\n",
-        "\n",
-        "1 point to you for each 50 points of your agent. Truncated by 5 points. Starting with 50 points, **not** 50 + threshold.\n",
-        "\n",
-        "One way is to train for several days and use heavier hardware (why not actually).\n",
-        "\n",
-        "Another way is to apply modifications (see **Bonus III**)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "u1p_nSNiYr--"
-      },
-      "source": [
-        "## Bonus III (2+ pts). Apply modifications to DQN.\n",
-        "\n",
-        "For inspiration see [Rainbow](https://arxiv.org/abs/1710.02298) - a version of q-learning that combines lots of them.\n",
-        "\n",
-        "Points for Bonus II and Bonus III fully stack. So if modified agent gets score 250+ you get 5 pts for Bonus II + points for modifications. If the final score is 40 then you get the points for modifications.\n",
-        "\n",
-        "\n",
-        "Some modifications:\n",
-        "* [Prioritized experience replay](https://arxiv.org/abs/1511.05952) (5 pts for your own implementation, 3 pts for using a ready one)\n",
-        "* [double q-learning](https://arxiv.org/abs/1509.06461) (2 pts)\n",
-        "* [dueling q-learning](https://arxiv.org/abs/1511.06581) (2 pts)\n",
-        "* multi-step heuristics (see [Rainbow](https://arxiv.org/abs/1710.02298)) (3 pts)\n",
-        "* [Noisy Nets](https://arxiv.org/abs/1706.10295) (3 pts)\n",
-        "* [distributional RL](https://arxiv.org/abs/1707.06887)(distributional and distributed stand for different things here) (5 pts)\n",
-        "* Other modifications (2+ pts depending on complexity)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "-mZXLIRbYr-_"
-      },
-      "source": [
-        "## Bonus IV (4+ pts). Distributed RL.\n",
-        "\n",
-        "Solve the task in a distributed way. It can strongly speed up learning. See [article](https://arxiv.org/pdf/1602.01783.pdf) or some guides."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "vK-v4sSBYr_B"
-      },
-      "source": [
-        "**As usual bonus points for all the tasks fully stack.**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "iOIjcJQuYr_D",
-        "colab": {}
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**This notebook is the main notebook.** Another notebook is given for debug. (**homework_pytorch_main**). The tasks are similar and share most of the code. The main difference is in environments. In main notebook it can take some 2 hours for the agent to start improving so it seems reasonable to launch the algorithm on a simpler env first. In debug one it is CartPole and it will train in several minutes.\n",
+    "\n",
+    "**We suggest the following pipeline:** First implement debug notebook then implement the main one.\n",
+    "\n",
+    "**About evaluation:** All points are given for the main notebook with one exception: if agent fails to beat the threshold in main notebook you can get 1 pt (instead of 3 pts) for beating the threshold in debug notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting virtual X frame buffer: Xvfb.\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "# in google colab uncomment this\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "os.system('apt-get update')\n",
+    "os.system('apt-get install -y xvfb')\n",
+    "os.system('wget https://raw.githubusercontent.com/yandexdataschool/Practical_DL/fall18/xvfb -O ../xvfb')\n",
+    "os.system('apt-get install -y python-opengl ffmpeg')\n",
+    "os.system('pip install pyglet==1.5.0')\n",
+    "\n",
+    "os.system('python -m pip install -U pygame --user')\n",
+    "\n",
+    "prefix = 'https://raw.githubusercontent.com/yandexdataschool/Practical_RL/master/week04_approx_rl/'\n",
+    "\n",
+    "os.system('wget ' + prefix + 'atari_wrappers.py')\n",
+    "os.system('wget ' + prefix + 'utils.py')\n",
+    "os.system('wget ' + prefix + 'replay_buffer.py')\n",
+    "os.system('wget ' + prefix + 'framebuffer.py')\n",
+    "\n",
+    "# print('setup complete')\n",
+    "\n",
+    "# XVFB will be launched if you run on a server\n",
+    "import os\n",
+    "if type(os.environ.get(\"DISPLAY\")) is not str or len(os.environ.get(\"DISPLAY\")) == 0:\n",
+    "    !bash ../xvfb start\n",
+    "    os.environ['DISPLAY'] = ':1'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Frameworks__ - we'll accept this homework in any deep learning framework. This particular notebook was designed for pytoch, but you find it easy to adapt it to almost any python-based deep learning framework."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Let's play some old videogames\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/nerd.png)\n",
+    "\n",
+    "This time we're gonna apply approximate q-learning to an atari game called Breakout. It's not the hardest thing out there, but it's definitely way more complex than anything we tried before.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_NAME = \"BreakoutNoFrameskip-v4\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preprocessing (3 pts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what observations look like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6UAAAH3CAYAAABD+PmTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3dbazkd3nf/8/1twMPNlQ2N7Us29SG\nOqmgah1YuVYL/GlpyGJFMfQBtVUFJ0VdkEBK5FSVCVJBlSK1aTASaupoEdaaKjHQOgSrclwcNwqq\nUhPWxDHmxtgmRni12AVXQJYIYvvbB+e3MFl295w9c/Od+Z7XSxqdOb+ZOXNZ+/bRXmfm/LZaawEA\nAIAe/r/eAwAAALB3WUoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG6WtpRW1YGqeqiqHqmq\nG5f1PNCDvhmdxhmdxhmdxtkktYx/p7Sqzkny5SQ/neTxJJ9Jcl1r7QsLfzJYMX0zOo0zOo0zOo2z\naZb1SumVSR5prX2ltfb9JB9Jcs2SngtWTd+MTuOMTuOMTuNslHOX9HUvSvK1mc8fT/IPZu9QVQeT\nHJw+feWS5oBZ32itvWgBX2fbvhON04XGGd3KGtc3HSyq70TjrKfTNr6spXRbrbVDSQ4lSVUt/j3E\n8KO+uson0zgdaJzRraxxfdOB7+GM7rSNL+vtu0eTXDLz+cXTMRiBvhmdxhmdxhmdxtkoy1pKP5Pk\n8qq6rKqek+TaJHcs6blg1fTN6DTO6DTO6DTORlnK23dba09X1TuT/I8k5yS5pbX2+WU816LddNNN\nO77vDTfcsOvHnvz4eR47r57PfbKTZ1nmc+3WJvedaHzVz30yjS+fxlf73CfT+HLpe7XPfbJN6DvR\n+G4er/EtvRpf2u+UttbuTHLnsr4+9KRvRqdxRqdxRqdxNkm3Ex1tgkX+9OVsHz/vc89jXX/qx+Jp\nnNFpnJHpm9FpfO9Y1u+UAgAAwLa8UsqP2O4nQXvxpzeMReOMTuOMTN+Mbi827pVSAAAAuvFKKdv+\ntGWV76GHZdA4o9M4I9M3o9O4V0oBAADoyCulZzDvTyXmefwqfyKyF376wqlpnNFpnJHpm9FpfO+o\n1lrvGVJV/YdgL7ivtba/xxNrnBXROKPr0ri+WRHfwxndaRv39l0AAAC6WYu371588cVDntqY9dKz\nMY2zChpndL0a0zer4Hs4oztTY14pBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC62fVSWlWX\nVNUfVtUXqurzVfVL0/H3VtXRqrp/uly9uHFhdTTO6DTOyPTN6DTOSOb5J2GeTvIrrbXPVtXzktxX\nVXdPt72/tfYb848HXWmc0Wmckemb0WmcYex6KW2tHUtybLr+nar6YpKLFjUY9KZxRqdxRqZvRqdx\nRrKQ3ymtqkuT/FSST0+H3llVD1TVLVV1/mkec7CqjlTVkePHjy9iDFgajTM6jTMyfTM6jbPp5l5K\nq+rHk9ye5Jdba99OcnOSlya5Ils/vXnfqR7XWjvUWtvfWtu/b9++eceApdE4o9M4I9M3o9M4I5hr\nKa2qH8vW/wS/3Vr73SRprT3RWnumtfZskg8muXL+MaEPjTM6jTMyfTM6jTOKec6+W0k+lOSLrbWb\nZo5fOHO3NyV5cPfjQT8aZ3QaZ2T6ZnQaZyTznH33HyX5+SSfq6r7p2O/muS6qroiSUvyWJK3zTUh\n9KNxRqdxRqZvRqdxhjHP2Xf/V5I6xU137n4cWB8aZ3QaZ2T6ZnQaZyTzvFK6MjfccEPvEdgAN910\n0/Z3WlMaZyc0zug2tXF9sxOb2neicXZmnsYX8k/CAAAAwG5YSgEAAOjGUgoAAEA3llIAAAC6sZQC\nAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUU\nAACAbs6d9wtU1WNJvpPkmSRPt9b2V9Xzk3w0yaVJHkvy5tba/533uWDV9M3oNM7oNM7I9M0oFvVK\n6T9urV3RWts/fX5jkntaa5cnuWf6HDaVvhmdxhmdxhmZvtl4y3r77jVJbp2u35rkjUt6HuhB34xO\n44xO44xM32ycRSylLcknq+q+qjo4HbugtXZsuv71JBec/KCqOlhVR6rqyPHjxxcwBizFrvpONM7G\n0Dij8/cURuZ7OEOY+3dKk7yqtXa0qv5mkrur6kuzN7bWWlW1kx/UWjuU5FCSXHLJJT9yO6yJXfU9\n3aZxNoHGGZ2/pzAy38MZwtyvlLbWjk4fn0zy8SRXJnmiqi5Mkunjk/M+D/Sgb0ancUancUamb0Yx\n11JaVfuq6nknrid5fZIHk9yR5Prpbtcn+cQ8zwM96JvRaZzRaZyR6ZuRzPv23QuSfLyqTnyt32mt\n3VVVn0nysap6a5KvJnnznM8DPeib0Wmc0WmckembYcy1lLbWvpLk75/i+DeTvG6erw296ZvRaZzR\naZyR6ZuRLOJER0t374EDvUdgA/xx7wHmoHF2QuOMblMb1zc7sal9JxpnZ+ZpfFn/TikAAABsy1IK\nAABAN5ZSAAAAurGUAgAA0I2lFAAAgG424uy7z/7tb/ceAZZK44xO44xM34xO4yybV0oBAADoxlIK\nAABAN5ZSAAAAurGUAgAA0I2lFAAAgG424uy7T/2N7/YeAZZK44xO44xM34xO4yybV0oBAADoxlIK\nAABAN7t++25V/WSSj84cekmSf5vkvCT/Ksn/mY7/amvtzl1PCJ1onNFpnNFpnJHpm5HseiltrT2U\n5IokqapzkhxN8vEkv5jk/a2131jIhNCJxhmdxhmdxhmZvhnJok509Lokj7bWvlpVC/qSP/TU3/n+\nwr8mA/rGUr+6xulP44xuQxvXNzuyoX0nGmeH5mh8Ub9Tem2S22Y+f2dVPVBVt1TV+Qt6DuhJ44xO\n44xO44xM32y0uZfSqnpOkp9L8l+nQzcneWm23k5wLMn7TvO4g1V1pKqOHD9+fN4xYGk0zug0zuh2\n07i+2RS+hzOCRbxS+oYkn22tPZEkrbUnWmvPtNaeTfLBJFee6kGttUOttf2ttf379u1bwBiwNBpn\ndBpndGfduL7ZIL6Hs/EWsZRel5m3C1TVhTO3vSnJgwt4DuhJ44xO44xO44xM32y8uU50VFX7kvx0\nkrfNHP71qroiSUvy2Em3wUbROKPTOKPTOCPTN6OYayltrR1P8oKTjv38XBOdwu88++JFf0kG9Pol\nfE2Ns040zug2tXF9sxOb2neicXZmnsYXdfZdAAAAOGuWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0\nM9fZd1fl+x95b+8R2ASv/+PeE+yaxtkRjTO6DW1c3+zIhvadaJwdmqNxr5QCAADQjaUUAACAbiyl\nAAAAdGMpBQAAoBtLKQAAAN1sxNl3/+ddV/UegQ3ws6+/qfcIu6ZxdkLjjG5TG9c3O7GpfScaZ2fm\nadwrpQAAAHRjKQUAAKAbSykAAADd7GgprapbqurJqnpw5tjzq+ruqnp4+nj+dLyq6gNV9UhVPVBV\nr1jW8LAI+mZ0Gmd0Gmdk+mYv2OkrpYeTHDjp2I1J7mmtXZ7knunzJHlDksuny8EkN88/JizV4eib\nsR2Oxhnb4WiccR2OvhncjpbS1tqnkjx10uFrktw6Xb81yRtnjn+4bbk3yXlVdeEihoVl0Dej0zij\n0zgj0zd7wTy/U3pBa+3YdP3rSS6Yrl+U5Gsz93t8OgabRN+MTuOMTuOMTN8MZSEnOmqttSTtbB5T\nVQer6khVHTl+/PgixoCl2E3ficbZHBpndP6ewsh8D2cE8yylT5x4O8D08cnp+NEkl8zc7+Lp2F/T\nWjvUWtvfWtu/b9++OcaApZir70TjrD2NMzp/T2FkvoczlHmW0juSXD9dvz7JJ2aOv2U6+9dVSb41\n8/YC2BT6ZnQaZ3QaZ2T6Zijn7uROVXVbktcmeWFVPZ7kPUn+fZKPVdVbk3w1yZunu9+Z5OokjyT5\nbpJfXPDMsFD6ZnQaZ3QaZ2T6Zi/Y0VLaWrvuNDe97hT3bUneMc9QsEr6ZnQaZ3QaZ2T6Zi9YyImO\nAAAAYDcspQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG4s\npQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAutl2Ka2qW6rqyap6cObYf6yqL1XV\nA1X18ao6bzp+aVX9ZVXdP11+a5nDwyJofL3ce+BA7j1woPcYQ9E4I9M3o9M4e8FOXik9nOTkvyHe\nneTvttb+XpIvJ3nXzG2PttaumC5vX8yYsFSHo3HGdjgaXwt+6LIUh6NvxnY4Gmdw2y6lrbVPJXnq\npGOfbK09PX16b5KLlzAbrITGGZ3GGZm+14MfuCyPxtkLFvE7pf8yye/PfH5ZVf1pVf1RVb16AV8f\netM4o9M4I9M3o9P4kvmhy/KdO8+Dq+rdSZ5O8tvToWNJXtxa+2ZVvTLJ71XVy1tr3z7FYw8mOZgk\n559//jxjwNJofPWuuuuu3iPsKRpnZPpmdBpnFLt+pbSqfiHJzyb5F621liStte+11r45Xb8vyaNJ\nfuJUj2+tHWqt7W+t7d+3b99ux4Cl0Tij0/jqXXXXXX7wsiL6ZnQaZyS7eqW0qg4k+TdJ/v/W2ndn\njr8oyVOttWeq6iVJLk/ylYVMCiukcUancUam79Xzw5bV0jij2XYprarbkrw2yQur6vEk78nWGb6e\nm+TuqkqSe6eze70myb+rqr9K8mySt7fWnjrlF4Y1oXFGp3FGpm9Gp/H+/NBl+bZdSltr153i8IdO\nc9/bk9w+71CwShpndBpnZPpmdBpnL1jE2XcBAABgVyylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjG\nUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3\nllIAAAC6sZQCAADQzbZLaVXdUlVPVtWDM8feW1VHq+r+6XL1zG3vqqpHquqhqvqZZQ0Oi6JxRqdx\nRqdxRqZv9oKdvFJ6OMmBUxx/f2vtiulyZ5JU1cuSXJvk5dNj/nNVnbOoYWFJDkfjjO1wNM7YDkfj\njOtw9M3gtl1KW2ufSvLUDr/eNUk+0lr7Xmvtz5M8kuTKOeaDpdM4o9M4o9M4I9M3e8E8v1P6zqp6\nYHpLwfnTsYuSfG3mPo9Px35EVR2sqiNVdeT48eNzjAFLo3FGp3FGt+vG9c0G8D2cYex2Kb05yUuT\nXJHkWJL3ne0XaK0daq3tb63t37dv3y7HgKXROKPTOKObq3F9s+Z8D2cou1pKW2tPtNaeaa09m+SD\n+eHbAo4muWTmrhdPx2CjaJzRaZzRaZyR6ZvR7GopraoLZz59U5ITZwO7I8m1VfXcqrosyeVJ/mS+\nEWH1NM7oNM7oNM7I9M1ozt3uDlV1W5LXJnlhVT2e5D1JXltVVyRpSR5L8rYkaa19vqo+luQLSZ5O\n8o7W2jPLGR0WQ+OMTuOMTuOMTN/sBdsupa21605x+ENnuP+vJfm1eYaCVdI4o9M4o9M4I9M3e8E8\nZ98FAACAuVhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0YykFAACgG0spAAAA\n3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0s+1SWlW3VNWTVfXgzLGPVtX9\n0+Wxqrp/On5pVf3lzG2/tczhYRE0zug0zsj0zeg0zl5w7g7uczjJf0ry4RMHWmv//MT1qnpfkm/N\n3P/R1toVixoQVuBwNM7YDkfjjOtw9M3YDkfjDG7bpbS19qmquvRUt1VVJXlzkn+y2LFgdTTO6DTO\nyPTN6DTOXjDv75S+OskTrbWHZ45dVlV/WlV/VFWvPt0Dq+pgVR2pqiPHjx+fcwxYGo0zOo0zMn0z\nOo0zhJ28ffdMrkty28znx5K8uLX2zap6ZZLfq6qXt9a+ffIDW2uHkhxKkksuuaTNOQcsi8YZncYZ\nmb4ZncYZwq5fKa2qc5P8syQfPXGstfa91to3p+v3JXk0yU/MOyT0oHFGp3FGpm9Gp3FGMs/bd/9p\nki+11h4/caCqXlRV50zXX5Lk8iRfmW9E6EbjjE7jjEzfjE7jDGMn/yTMbUn+d5KfrKrHq+qt003X\n5q+/XSBJXpPkgem01P8tydtba08tcmBYNI0zOo0zMn0zOo2zF+zk7LvXneb4L5zi2O1Jbp9/LFgd\njTM6jTMyfTM6jbMXzHv2XQAAANg1SykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAA\ngG62/XdKV+Fb5zyb/37eX/QeY0+698CBuR5/1V13LWiS+f3DT36y9winpfF+NL4aGu9H48un7370\nvRoa70fjW7xSCgAAQDeWUgAAALqxlAIAANDNWvxOKf2s0/vQYRk0zug0zsj0zeg0vsVSyjD8T83o\nNM7oNM7I9M3o5mm8WmsLHGWXQ1T1H4K94L7W2v4eT6xxVkTjjK5L4/pmRXwPZ3SnbdzvlAIAANDN\ntktpVV1SVX9YVV+oqs9X1S9Nx59fVXdX1cPTx/On41VVH6iqR6rqgap6xbL/I2AeGmd0Gmdk+mZ0\nGmcv2MkrpU8n+ZXW2suSXJXkHVX1siQ3JrmntXZ5knumz5PkDUkuny4Hk9y88KlhsTTO6DTOyPTN\n6DTO8LZdSltrx1prn52ufyfJF5NclOSaJLdOd7s1yRun69ck+XDbcm+S86rqwoVPDguicUancUam\nb0ancfaCs/qd0qq6NMlPJfl0kgtaa8emm76e5ILp+kVJvjbzsMenYyd/rYNVdaSqjpzlzLA0Gmd0\nGmdk+mZ0GmdUO15Kq+rHk9ye5Jdba9+eva1tncL3rM7a1Vo71Frb3+ssY3AyjTM6jTMyfTM6jTOy\nHS2lVfVj2fqf4Ldba787HX7ixFsBpo9PTsePJrlk5uEXT8dgbWmc0Wmckemb0Wmc0e3k7LuV5ENJ\nvthau2nmpjuSXD9dvz7JJ2aOv2U689dVSb4189YCWDsaZ3QaZ2T6ZnQaZ09orZ3xkuRV2Xo7wANJ\n7p8uVyd5QbbO9PVwkj9I8vzp/pXkN5M8muRzSfbv4Dmai8sKLkc07jL4ReMuo19+pPHo22Wci+/h\nLqNfTtl4ay01hdhVVfUfgr3gvl6/N6FxVkTjjK5L4/pmRXwPZ3Snbfyszr4LAAAAi2QpBQAAoBtL\nKQAAAN2c23uAyTeSHJ8+bqoXxvw97WT+v7WKQU5D4/3thfl7Nv4XSR7q+Pzz2gt9rLt1btz38P72\nwvz+njKfvdDIOpur8bU40VGSVNWRTf7He83f1ybMvwkznon5+1r3+dd9vu2Yv791/29Y9/m2Y/6+\nNmH+TZjxTMzf17zze/suAAAA3VhKAQAA6GadltJDvQeYk/n72oT5N2HGMzF/X+s+/7rPtx3z97fu\n/w3rPt92zN/XJsy/CTOeifn7mmv+tfmdUgAAAPaedXqlFAAAgD3GUgoAAEA33ZfSqjpQVQ9V1SNV\ndWPveXaiqh6rqs9V1f1VdWQ69vyquruqHp4+nt97zllVdUtVPVlVD84cO+XMteUD05/JA1X1in6T\n/2DWU83/3qo6Ov053F9VV8/c9q5p/oeq6mf6TP2DWTS+ZPruS+PLp/F+NrHvROOrpvHV2rS+E41v\n+wSttW6XJOckeTTJS5I8J8mfJXlZz5l2OPdjSV540rFfT3LjdP3GJP+h95wnzfeaJK9I8uB2Mye5\nOsnvJ6kkVyX59JrO/94k//oU933Z1NJzk1w2NXZOp7k13q8Pfa9mdo33a0Tjy597I/ueZtd4//k1\nvry5N6rvMzSi8enS+5XSK5M80lr7Smvt+0k+kuSazjPt1jVJbp2u35rkjR1n+RGttU8leeqkw6eb\n+ZokH25b7k1yXlVduJpJT+0085/ONUk+0lr7Xmvtz5M8kq3WetD4Cui7W9+JxldC476HL4jGl0Tj\na2Ft+040nm0a772UXpTkazOfPz4dW3ctySer6r6qOjgdu6C1dmy6/vUkF/QZ7aycbuZN+nN55/S2\nhltm3qaxTvOv0yxnY4TG9b0a6zbPTml8Pax74+s0y9nS+HrQ+HKM0Hei8R/ovZRuqle11l6R5A1J\n3lFVr5m9sW29br1R/9bOJs6c5OYkL01yRZJjSd7Xd5yhDNX4ps070fdyabw/jS+XxvvT+PIM1Xey\nmTNngY33XkqPJrlk5vOLp2NrrbV2dPr4ZJKPZ+vl6CdOvKw+fXyy34Q7drqZN+LPpbX2RGvtmdba\ns0k+mB++LWCd5l+nWXZskMb1vRrrNs+OaLy/DWl8nWY5KxrvT+PLM0jficZ/oPdS+pkkl1fVZVX1\nnCTXJrmj80xnVFX7qup5J64neX2SB7M19/XT3a5P8ok+E56V0818R5K3TGf+uirJt2beWrA2Tnpv\n/Zuy9eeQbM1/bVU9t6ouS3J5kj9Z9XwTjfej79XQeD8aX76N6zvR+LrQ+HIM1Hei8R8601mQVnHJ\n1tmlvpytszK9u/c8O5j3Jdk6m9SfJfn8iZmTvCDJPUkeTvIHSZ7fe9aT5r4tWy+r/1W23tf91tPN\nnK0zff3m9GfyuST713T+/zLN98AU/4Uz93/3NP9DSd7QeXaN9+lD36ubX+N9GtH4ambfqL6nmTW+\nHvNrfDnzblzfZ2hE49OlpgcBAADAyvV++y4AAAB7mKUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1Y\nSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjG\nUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3\nllIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6\nsZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQ\njaUUAACAbiylAAAAdGMpBQAAoBtLKQAAAN0sbSmtqgNV9VBVPVJVNy7reaAHfTM6jTM6jTM6jbNJ\nqrW2+C9adU6SLyf56SSPJ/lMkutaa19Y+JPBiumb0Wmc0Wmc0WmcTbOsV0qvTPJIa+0rrbXvJ/lI\nkmuW9FywavpmdBpndBpndBpno5y7pK97UZKvzXz+eJJ/MHuHqjqY5OD06SuXNAfM+kZr7UUL+Drb\n9p1onC40zuhW1ri+6WBRfScaZz2dtvFlLaXbaq0dSnIoSapq8e8hhh/11VU+mcbpQOOMbmWN65sO\nfA9ndKdtfFlv3z2a5JKZzy+ejsEI9M3oNM7oNM7oNM5GWdZS+pkkl1fVZVX1nCTXJrljSc8Fq6Zv\nRqdxRqdxRqdxNspS3r7bWnu6qt6Z5H8kOSfJLa21zy/juRbtpptu2vF9b7jhhl0/9uTHz/PYefV8\n7pOdPMsyn2u3NrnvROOrfu6TaXz5NL7a5z6ZxpdL36t97pNtQt+JxnfzeI1v6dX40n6ntLV2Z5I7\nl/X1oSd9MzqNMzqNMzqNs0m6nehoEyzypy9n+/h5n3se6/pTPxZP44xO44xM34xO43vHsn6nFAAA\nALbllVJ+xHY/CdqLP71hLBpndBpnZPpmdHuxca+UAgAA0I1XStn2py2rfA89LIPGGZ3GGZm+GZ3G\nvVIKAABAR14pPYN5fyoxz+NX+RORvfDTF05N44xO44xM34xO43tHtdZ6z5Cq6j8Ee8F9rbX9PZ5Y\n46yIxhldl8b1zYr4Hs7oTtu4t+8CAADQzVq8fffiiy8e8tTGrJeejWmcVdA4o+vVmL5ZBd/DGd2Z\nGvNKKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQza6X0qq6pKr+sKq+UFWfr6pfmo6/t6qO\nVtX90+XqxY0Lq6NxRqdxRqZvRqdxRjLPPwnzdJJfaa19tqqel+S+qrp7uu39rbXfmH886ErjjE7j\njEzfjE7jDGPXS2lr7ViSY9P171TVF5NctKjBoDeNMzqNMzJ9MzqNM5KF/E5pVV2a5KeSfHo69M6q\neqCqbqmq80/zmINVdaSqjhw/fnwRY8DSaJzRaZyR6ZvRaZxNN/dSWlU/nuT2JL/cWvt2kpuTvDTJ\nFdn66c37TvW41tqh1tr+1tr+ffv2zTsGLI3GGZ3GGZm+GZ3GGcFcS2lV/Vi2/if47dba7yZJa+2J\n1tozrbVnk3wwyZXzjwl9aJzRaZyR6ZvRaZxRzHP23UryoSRfbK3dNHP8wpm7vSnJg7sfD/rROKPT\nOCPTN6PTOCOZ5+y7/yjJzyf5XFXdPx371STXVdUVSVqSx5K8ba4JoR+NMzqNMzJ9MzqNM4x5zr77\nv5LUKW66c/fjwPrQOKPTOCPTN6PTOCOZ55XSlbnhhht6j8AGuOmmm7a/05rSODuhcUa3qY3rm53Y\n1L4TjbMz8zS+kH8SBgAAAHbDUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAAoBtL\nKQAAAN1YSgEAAOjGUgoAAEA3llIAAAC6sZQCAADQjaUUAACAbiylAAAAdHPuvF+gqh5L8p0kzyR5\nurW2v6qen+SjSS5N8liSN7fW/u+8zwWrpm9Gp3FGp3FGpm9GsahXSv9xa+2K1tr+6fMbk9zTWrs8\nyT3T57Cp9M3oNM7oNM7I9M3GW9bbd69Jcut0/dYkb1zS80AP+mZ0Gmd0Gmdk+mbjLGIpbUk+WVX3\nVdXB6dgFrbVj0/WvJ7ng5AdV1cGqOlJVR44fP76AMWApdtV3onE2hsYZnb+nMDLfwxnC3L9TmuRV\nrbWjVfU3k9xdVV+avbG11qqqnfyg1tqhJIeS5JJLLvmR22FN7Krv6TaNswk0zuj8PYWR+R7OEOZ+\npbS1dnT6+GSSjye5MskTVXVhkkwfn5z3eaAHfTM6jTM6jTMyfTOKuZbSqtpXVc87cT3J65M8mOSO\nJNdPd7s+ySfmeR7oQd+MTmOrsbMAABLfSURBVOOMTuOMTN+MZN63716Q5ONVdeJr/U5r7a6q+kyS\nj1XVW5N8Ncmb53we6EHfjE7jjE7jjEzfDGOupbS19pUkf/8Ux7+Z5HXzfG3oTd+MTuOMTuOMTN+M\nZBEnOlq6ew8c6D0CG+CPew8wB42zExpndJvauL7ZiU3tO9E4OzNP48v6d0oBAABgW5ZSAAAAurGU\nAgAA0I2lFAAAgG4spQAAAHSzEWffffZvf7v3CLBUGmd0Gmdk+mZ0GmfZvFIKAABAN5ZSAAAAurGU\nAgAA0I2lFAAAgG4spQAAAHSzEWfffepvfLf3CLBUGmd0Gmdk+mZ0GmfZvFIKAABAN5ZSAAAAutn1\n23er6ieTfHTm0EuS/Nsk5yX5V0n+z3T8V1trd+56QuhE44xO44xO44xM34xk10tpa+2hJFckSVWd\nk+Roko8n+cUk72+t/cZCJoRONM7oNM7oNM7I9M1IFnWio9clebS19tWqWtCX/KGn/s73F/41GdA3\nlvrVNU5/Gmd0G9q4vtmRDe070Tg7NEfji/qd0muT3Dbz+Tur6oGquqWqzj/VA6rqYFUdqaojx48f\nX9AYsDQaZ3QaZ3Rn1bi+2TC+h7PR5l5Kq+o5SX4uyX+dDt2c5KXZejvBsSTvO9XjWmuHWmv7W2v7\n9+3bN+8YsDQaZ3QaZ3S7aVzfbArfwxnBIl4pfUOSz7bWnkiS1toTrbVnWmvPJvlgkisX8BzQk8YZ\nncYZncYZmb7ZeItYSq/LzNsFqurCmdvelOTBBTwH9KRxRqdxRqdxRqZvNt5cJzqqqn1JfjrJ22YO\n/3pVXZGkJXnspNtgo2ic0Wmc0WmckembUcy1lLbWjid5wUnHfn6uiU7hd5598aK/JAN6/RK+psZZ\nJxpndJvauL7ZiU3tO9E4OzNP44s6+y4AAACcNUspAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqZ6+y7\nq/L9j7y39whsgtf/ce8Jdk3j7IjGGd2GNq5vdmRD+040zg7N0bhXSgEAAOjGUgoAAEA3llIAAAC6\nsZQCAADQjaUUAACAbjbi7Lv/866reo/ABvjZ19/Ue4Rd0zg7oXFGt6mN65ud2NS+E42zM/M07pVS\nAAAAurGUAgAA0I2lFAAAgG52tJRW1S1V9WRVPThz7PlVdXdVPTx9PH86XlX1gap6pKoeqKpXLGt4\nWAR9MzqNMzqNMzJ9sxfs9JXSw0kOnHTsxiT3tNYuT3LP9HmSvCHJ5dPlYJKb5x8Tlupw9M3YDkfj\njO1wNM64DkffDG5HS2lr7VNJnjrp8DVJbp2u35rkjTPHP9y23JvkvKq6cBHDwjLom9FpnNFpnJHp\nm71gnt8pvaC1dmy6/vUkF0zXL0rytZn7PT4d+2uq6mBVHamqI8ePH59jDFiKufpONM7a0zij8/cU\nRuZ7OENZyImOWmstSTvLxxxqre1vre3ft2/fIsaApdhN39PjNM5G0Dij8/cURuZ7OCOYZyl94sTb\nAaaPT07Hjya5ZOZ+F0/HYJPom9FpnNFpnJHpm6HMs5TekeT66fr1ST4xc/wt09m/rkryrZm3F8Cm\n0Dej0zij0zgj0zdDOXcnd6qq25K8NskLq+rxJO9J8u+TfKyq3prkq0nePN39ziRXJ3kkyXeT/OKC\nZ4aF0jej0zij0zgj0zd7wY6W0tbadae56XWnuG9L8o55hoJV0jej0zij0zgj0zd7wUJOdAQAAAC7\nYSkFAACgG0spAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANCNpRQAAIBuLKUAAAB0YykFAACg\nG0spAAAA3VhKAQAA6MZSCgAAQDeWUgAAALqxlAIAANDNtktpVd1SVU9W1YMzx/5jVX2pqh6oqo9X\n1XnT8Uur6i+r6v7p8lvLHB4WQeOMTuOMTN+MTuPsBTt5pfRwkgMnHbs7yd9trf29JF9O8q6Z2x5t\nrV0xXd6+mDFhqQ5H44ztcDTOuA5H34ztcDTO4LZdSltrn0ry1EnHPtlae3r69N4kFy9hNlgJjTM6\njTMyfTM6jbMXLOJ3Sv9lkt+f+fyyqvrTqvqjqnr1Ar4+9KZxRqdxRqZvRqdxNt658zy4qt6d5Okk\nvz0dOpbkxa21b1bVK5P8XlW9vLX27VM89mCSg0ly/vnnzzPG0O49sPVujavuuqvzJHuTxhmdxhmZ\nvhmdxhnFrl8prapfSPKzSf5Fa60lSWvte621b07X70vyaJKfONXjW2uHWmv7W2v79+3bt9sxYGk0\nvnz3Hjjwgx+8sHoaZ2T6ZnQaZyS7Wkqr6kCSf5Pk51pr3505/qKqOme6/pIklyf5yiIGhVXSOKPT\n+PL5oUs/+mZ0Gmc02759t6puS/LaJC+sqseTvCdbZ/h6bpK7qypJ7p3O7vWaJP+uqv4qybNJ3t5a\ne+qUXxjWhMYZncYZmb5Xz68WrZbG2Qu2XUpba9ed4vCHTnPf25PcPu9Q/JBv+MuncUancUamb0an\n8dXyQ5c+5jrREcA8fMMHAMBSCgBL4IcuALAzllIAAHbMD1yARbOUAgAAxA9detn1v1MKAAAA87KU\nAgAA0I2lFAAAgG4spQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2l\nFAAAgG62XUqr6paqerKqHpw59t6qOlpV90+Xq2due1dVPVJVD1XVzyxrcFgUjTM6jTM6jTMyfbMX\n7OSV0sNJDpzi+Ptba1dMlzuTpKpeluTaJC+fHvOfq+qcRQ0LS3I4Gmdsh6NxxnY4Gmdch6NvBrft\nUtpa+1SSp3b49a5J8pHW2vdaa3+e5JEkV84xHyydxhmdxhmdxhmZvtkL5vmd0ndW1QPTWwrOn45d\nlORrM/d5fDoGm0jjjE7jjE7jjEzfDGO3S+nNSV6a5Iokx5K872y/QFUdrKojVXXk+PHjuxwDlkbj\njE7jjG6uxvXNmvM9nKHsailtrT3RWnumtfZskg/mh28LOJrkkpm7XjwdO9XXONRa299a279v377d\njAFLo3FGp3FGN2/j+mad+R7OaHa1lFbVhTOfvinJibOB3ZHk2qp6blVdluTyJH8y34iwehpndBpn\ndBpnZPpmNOdud4equi3Ja5O8sKoeT/KeJK+tqiuStCSPJXlbkrTWPl9VH0vyhSRPJ3lHa+2Z5YwO\ni6FxRqdxRqdxRqZv9oJtl9LW2nWnOPyhM9z/15L82jxDwSppnNFpnNFpnJHpm71gnrPvAgAAwFws\npQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAurGUAgAA0I2lFAAAgG4spQAAAHRj\nKQUAAKAbSykAAADdWEoBAADoxlIKAABAN5ZSAAAAutl2Ka2qW6rqyap6cObYR6vq/unyWFXdPx2/\ntKr+cua231rm8LAIGmd0Gmdk+mZ0GmcvOHcH9zmc5D8l+fCJA621f37ielW9L8m3Zu7/aGvtikUN\nCCtwOBpnbIejccZ1OPpmbIejcQa37VLaWvtUVV16qtuqqpK8Ock/WexYsDoaZ3QaZ2T6ZnQaZy+Y\n93dKX53kidbawzPHLquqP62qP6qqV8/59aE3jTM6jTMyfTM6jTOEnbx990yuS3LbzOfHkry4tfbN\nqnplkt+rqpe31r598gOr6mCSg0ly/vnnzzkGLI3GGZ3GGZm+GZ3GGcKuXymtqnOT/LMkHz1xrLX2\nvdbaN6fr9yV5NMlPnOrxrbVDrbX9rbX9+/bt2+0YsDQaZ3QaZ2T6ZnQaZyTzvH33nyb5Umvt8RMH\nqupFVXXOdP0lSS5P8pX5RoRuNM7oNM7I9M3oNM4wdvJPwtyW5H8n+cmqeryq3jrddG3++tsFkuQ1\nSR6YTkv935K8vbX21CIHhkXTOKPTOCPTN6PTOHvBTs6+e91pjv/CKY7dnuT2+ceC1dE4o9M4I9M3\no9M4e8G8Z98FAACAXbOUAgAA0I2lFAAAgG4spQAAAHRjKQUAAKAbSykAAADdWEoBAADoxlIKAABA\nN+f2HiBJvnXOs/nv5/1F7zH2jHsPHJjr8VfdddeCJlmsf/jJT/Ye4bQ0vjqj9p1onLH7Tta3cX2v\nhr770fhqaPz0vFIKAABAN5ZSAAAAurGUAgAA0M1a/E4pq7Xu70eHeeibkembkemb0Wn89CylDMP/\n6IxO44xO44xM34xunsartbbAUXY5RFX/IdgL7mut7e/xxBpnRTTO6Lo0rm9WxPdwRnfaxrf9ndKq\nuqSq/rCqvlBVn6+qX5qOP7+q7q6qh6eP50/Hq6o+UFWPVNUDVfWKxf63wGJpnNFpnJHpm9FpnL1g\nJyc6ejrJr7TWXpbkqiTvqKqXJbkxyT2ttcuT3DN9niRvSHL5dDmY5OaFTw2LpXFGp3FGpm9Gp3GG\nt+1S2lo71lr77HT9O0m+mOSiJNckuXW6261J3jhdvybJh9uWe5OcV1UXLnxyWBCNMzqNMzJ9MzqN\nsxec1T8JU1WXJvmpJJ9OckFr7dh009eTXDBdvyjJ12Ye9vh0DNaexhmdxhmZvhmdxhnVjs++W1U/\nnuT2JL/cWvt2Vf3gttZaO9tfkK6qg9l6SwGsBY0zOo0zMn0zOo0zsh29UlpVP5at/wl+u7X2u9Ph\nJ068FWD6+OR0/GiSS2YefvF07K9prR1qre3vdZYxmKVxRqdxRqZvRqdxRreTs+9Wkg8l+WJr7aaZ\nm+5Icv10/fokn5g5/pbpzF9XJfnWzFsLYO1onNFpnJHpm9FpnD2htXbGS5JXJWlJHkhy/3S5OskL\nsnWmr4eT/EGS50/3ryS/meTRJJ9Lsn8Hz9FcXFZwOaJxl8EvGncZ/fIjjUffLuNcfA93Gf1yysZb\na6kpxK7O9j3wsEv+UWpGp3FG16VxfbMivoczutM2flZn3wUAAIBFspQCAADQjaUUAACAbiylAAAA\ndHNu7wEm30hyfPq4qV4Y8/e0k/n/1ioGOQ2N97cX5u/Z+F8keajj889rL/Sx7ta5cd/D+9sL8/t7\nynz2QiPrbK7G1+Lsu0lSVUc2+R/vNX9fmzD/Jsx4Jubva93nX/f5tmP+/tb9v2Hd59uO+fvahPk3\nYcYzMX9f887v7bsAAAB0YykFAACgm3VaSg/1HmBO5u9rE+bfhBnPxPx9rfv86z7fdszf37r/N6z7\nfNsxf1+bMP8mzHgm5u9rrvnX5ndKAQAA2HvW6ZVSAAAA9hhLKQAAAN10X0qr6kBVPVRVj1TVjb3n\n2YmqeqyqPldV91fVkenY86vq7qp6ePp4fu85Z1XVLVX1ZFU9OHPslDPXlg9MfyYPVNUr+k3+g1lP\nNf97q+ro9Odwf1VdPXPbu6b5H6qqn+kz9Q9m0fiS6bsvjS+fxvvZxL4Tja+axldr0/pONL7tE7TW\nul2SnJPk0SQvSfKcJH+W5GU9Z9rh3I8leeFJx349yY3T9RuT/Ifec54032uSvCLJg9vNnOTqJL+f\npJJcleTTazr/e5P861Pc92VTS89NctnU2Dmd5tZ4vz70vZrZNd6vEY0vf+6N7HuaXeP959f48ube\nqL7P0IjGp0vvV0qvTPJIa+0rrbXvJ/lIkms6z7Rb1yS5dbp+a5I3dpzlR7TWPpXkqZMOn27ma5J8\nuG25N8l5VXXhaiY9tdPMfzrXJPlIa+17rbU/T/JItlrrQeMroO9ufScaXwmN+x6+IBpfEo2vhbXt\nO9F4tmm891J6UZKvzXz++HRs3bUkn6yq+6rq4HTsgtbasen615Nc0Ge0s3K6mTfpz+Wd09sabpl5\nm8Y6zb9Os5yNERrX92qs2zw7pfH1sO6Nr9MsZ0vj60HjyzFC34nGf6D3UrqpXtVae0WSNyR5R1W9\nZvbGtvW69Ub9WzubOHOSm5O8NMkVSY4leV/fcYYyVOObNu9E38ul8f40vlwa70/jyzNU38lmzpwF\nNt57KT2a5JKZzy+ejq211trR6eOTST6erZejnzjxsvr08cl+E+7Y6WbeiD+X1toTrbVnWmvPJvlg\nfvi2gHWaf51m2bFBGtf3aqzbPDui8f42pPF1muWsaLw/jS/PIH0nGv+B3kvpZ5JcXlWXVdVzklyb\n5I7OM51RVe2rqueduJ7k9UkezNbc1093uz7JJ/pMeFZON/MdSd4ynfnrqiTfmnlrwdo46b31b8rW\nn0OyNf+1VfXcqrosyeVJ/mTV80003o++V0Pj/Wh8+Tau70Tj60LjyzFQ34nGf+hMZ0FaxSVbZ5f6\ncrbOyvTu3vPsYN6XZOtsUn+W5PMnZk7ygiT3JHk4yR8keX7vWU+a+7Zsvaz+V9l6X/dbTzdzts70\n9ZvTn8nnkuxf0/n/yzTfA1P8F87c/93T/A8leUPn2TXepw99r25+jfdpROOrmX2j+p5m1vh6zK/x\n5cy7cX2foRGNT5eaHgQAAAAr1/vtuwAAAOxhllIAAAC6sZQCAADQjaUUAACAbiylAAAAdGMpBQAA\noBtLKQAAAN38P4MFx8hKCA3KAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1152x648 with 10 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "env = gym.make(ENV_NAME)\n",
+    "env.reset()\n",
+    "\n",
+    "n_cols = 5\n",
+    "n_rows = 2\n",
+    "fig = plt.figure(figsize=(16, 9))\n",
+    "\n",
+    "for row in range(n_rows):\n",
+    "    for col in range(n_cols):\n",
+    "        ax = fig.add_subplot(n_rows, n_cols, row * n_cols + col + 1)\n",
+    "        ax.imshow(env.render('rgb_array'))\n",
+    "        env.step(env.action_space.sample())\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Let's play a little.**\n",
+    "\n",
+    "Pay attention to zoom and fps args of play function. Control: A, D, space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # does not work in colab.\n",
+    "# # make keyboard interrupt to continue\n",
+    "\n",
+    "# from gym.utils.play import play\n",
+    "\n",
+    "# play(env=gym.make(ENV_NAME), zoom=5, fps=30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Processing game image \n",
+    "\n",
+    "Raw atari images are large, 210x160x3 by default. However, we don't need that level of detail in order to learn them.\n",
+    "\n",
+    "We can thus save a lot of time by preprocessing game image, including\n",
+    "* Resizing to a smaller shape, 64 x 64\n",
+    "* Converting to grayscale\n",
+    "* Cropping irrelevant image parts (top, bottom and edges)\n",
+    "\n",
+    "Also please keep one dimension for channel so that final shape would be 1 x 64 x 64.\n",
+    "\n",
+    "Tip: You can implement your own grayscale converter and assign a huge weight to the red channel. This dirty trick is not necessary but it will speed up learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gym.core import ObservationWrapper\n",
+    "from gym.spaces import Box\n",
+    "\n",
+    "\n",
+    "class PreprocessAtariObs(ObservationWrapper):\n",
+    "    def __init__(self, env):\n",
+    "        \"\"\"A gym wrapper that crops, scales image into the desired shapes and grayscales it.\"\"\"\n",
+    "        ObservationWrapper.__init__(self, env)\n",
+    "\n",
+    "        self.img_size = (1, 64, 64)\n",
+    "        self.observation_space = Box(0.0, 1.0, self.img_size)\n",
+    "\n",
+    "\n",
+    "    def _to_gray_scale(self, rgb, channel_weights=[0.8, 0.1, 0.1]):\n",
+    "        <Your code here>\n",
+    "\n",
+    "\n",
+    "    def observation(self, img):\n",
+    "        \"\"\"what happens to each observation\"\"\"\n",
+    "\n",
+    "        # Here's what you need to do:\n",
+    "        #  * crop image, remove irrelevant parts\n",
+    "        #  * resize image to self.img_size\n",
+    "        #     (use imresize from any library you want,\n",
+    "        #      e.g. opencv, skimage, PIL, keras)\n",
+    "        #  * cast image to grayscale\n",
+    "        #  * convert image pixels to (0,1) range, float32 type\n",
+    "        <Your code here>\n",
+    "        return < ... >"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "# spawn game instance for tests\n",
+    "env = gym.make(ENV_NAME)  # create raw env\n",
+    "env = PreprocessAtariObs(env)\n",
+    "observation_shape = env.observation_space.shape\n",
+    "n_actions = env.action_space.n\n",
+    "env.reset()\n",
+    "obs, _, _, _ = env.step(env.action_space.sample())\n",
+    "\n",
+    "# test observation\n",
+    "assert obs.ndim == 3, \"observation must be [channel, h, w] even if there's just one channel\"\n",
+    "assert obs.shape == observation_shape\n",
+    "assert obs.dtype == 'float32'\n",
+    "assert len(np.unique(obs)) > 2, \"your image must not be binary\"\n",
+    "assert 0 <= np.min(obs) and np.max(\n",
+    "    obs) <= 1, \"convert image pixels to [0,1] range\"\n",
+    "\n",
+    "assert np.max(obs) >= 0.5, \"It would be easier to see a brighter observation\"\n",
+    "assert np.mean(obs) >= 0.1, \"It would be easier to see a brighter observation\"\n",
+    "\n",
+    "print(\"Formal tests seem fine. Here's an example of what you'll get.\")\n",
+    "\n",
+    "n_cols = 5\n",
+    "n_rows = 2\n",
+    "fig = plt.figure(figsize=(16, 9))\n",
+    "obs = env.reset()\n",
+    "for row in range(n_rows):\n",
+    "    for col in range(n_cols):\n",
+    "        ax = fig.add_subplot(n_rows, n_cols, row * n_cols + col + 1)\n",
+    "        ax.imshow(obs[0, :, :], interpolation='none', cmap='gray')\n",
+    "        obs, _, _, _ = env.step(env.action_space.sample())\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wrapping."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**About the game:** You have 5 lives and get points for breaking the wall. Higher bricks cost more than the lower ones. There are 4 actions: start game (should be called at the beginning and after each life is lost), move left, move right and do nothing. There are some common wrappers used for Atari environments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "import atari_wrappers\n",
+    "\n",
+    "def PrimaryAtariWrap(env, clip_rewards=True):\n",
+    "    assert 'NoFrameskip' in env.spec.id\n",
+    "\n",
+    "    # This wrapper holds the same action for <skip> frames and outputs\n",
+    "    # the maximal pixel value of 2 last frames (to handle blinking\n",
+    "    # in some envs)\n",
+    "    env = atari_wrappers.MaxAndSkipEnv(env, skip=4)\n",
+    "\n",
+    "    # This wrapper sends done=True when each life is lost\n",
+    "    # (not all the 5 lives that are givern by the game rules).\n",
+    "    # It should make easier for the agent to understand that losing is bad.\n",
+    "    env = atari_wrappers.EpisodicLifeEnv(env)\n",
+    "\n",
+    "    # This wrapper laucnhes the ball when an episode starts.\n",
+    "    # Without it the agent has to learn this action, too.\n",
+    "    # Actually it can but learning would take longer.\n",
+    "    env = atari_wrappers.FireResetEnv(env)\n",
+    "\n",
+    "    # This wrapper transforms rewards to {-1, 0, 1} according to their sign\n",
+    "    if clip_rewards:\n",
+    "        env = atari_wrappers.ClipRewardEnv(env)\n",
+    "\n",
+    "    # This wrapper is yours :)\n",
+    "    env = PreprocessAtariObs(env)\n",
+    "    return env"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Let's see if the game is still playable after applying the wrappers.**\n",
+    "At playing the EpisodicLifeEnv wrapper seems not to work but actually it does (because after when life finishes a new ball is dropped automatically - it means that FireResetEnv wrapper understands that a new episode began)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # does not work in colab.\n",
+    "# # make keyboard interrupt to continue\n",
+    "\n",
+    "# from gym.utils.play import play\n",
+    "\n",
+    "# def make_play_env():\n",
+    "#     env = gym.make(ENV_NAME)\n",
+    "#     env = PrimaryAtariWrap(env)\n",
+    "# # in torch imgs have shape [c, h, w] instead of common [h, w, c]\n",
+    "#     env = atari_wrappers.AntiTorchWrapper(env)\n",
+    "#     return env\n",
+    "\n",
+    "# play(make_play_env(), zoom=10, fps=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Frame buffer\n",
+    "\n",
+    "Our agent can only process one observation at a time, so we gotta make sure it contains enough information to find optimal actions. For instance, agent has to react to moving objects so he must be able to measure object's velocity.\n",
+    "\n",
+    "To do so, we introduce a buffer that stores 4 last images. This time everything is pre-implemented for you, not really by the staff of the course :)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from framebuffer import FrameBuffer\n",
+    "\n",
+    "def make_env(clip_rewards=True, seed=None):\n",
+    "    env = gym.make(ENV_NAME)  # create raw env\n",
+    "    if seed is not None:\n",
+    "        env.seed(seed)\n",
+    "    env = PrimaryAtariWrap(env, clip_rewards)\n",
+    "    env = FrameBuffer(env, n_frames=4, dim_order='pytorch')\n",
+    "    return env\n",
+    "\n",
+    "env = make_env()\n",
+    "env.reset()\n",
+    "n_actions = env.action_space.n\n",
+    "state_shape = env.observation_space.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for _ in range(12):\n",
+    "    obs, _, _, _ = env.step(env.action_space.sample())\n",
+    "\n",
+    "plt.figure(figsize=[12,10])\n",
+    "plt.title(\"Game image\")\n",
+    "plt.imshow(env.render(\"rgb_array\"))\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=[15,15])\n",
+    "plt.title(\"Agent observation (4 frames top to bottom)\")\n",
+    "plt.imshow(utils.img_by_obs(obs, state_shape), cmap='gray')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DQN as it is (4 pts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Building a network\n",
+    "\n",
+    "We now need to build a neural network that can map images to state q-values. This network will be called on every agent's step so it better not be resnet-152 unless you have an array of GPUs. Instead, you can use strided convolutions with a small number of features to save time and memory.\n",
+    "\n",
+    "You can build any architecture you want, but for reference, here's something that will more or less work:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/dqn_arch.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Dueling network: (+2 pts)**\n",
+    "$$Q_{\\theta}(s, a) = V_{\\eta}(f_{\\xi}(s)) + A_{\\psi}(f_{\\xi}(s), a) - \\frac{\\sum_{a'}A_{\\psi}(f_{\\xi}(s), a')}{N_{actions}},$$\n",
+    "where $\\xi$, $\\eta$, and $\\psi$ are, respectively, the parameters of the\n",
+    "shared encoder $f_ξ$ , of the value stream $V_\\eta$ , and of the advan\n",
+    "tage stream $A_\\psi$; and $\\theta = \\{\\xi, \\eta, \\psi\\}$ is their concatenation.\n",
+    "\n",
+    "For the architecture on the image $V$ and $A$ heads can follow the dense layer instead of $Q$. Please don't worry that the model becomes a little bigger."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "# those who have a GPU but feel unfair to use it can uncomment:\n",
+    "# device = torch.device('cpu')\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def conv2d_size_out(size, kernel_size, stride):\n",
+    "    \"\"\"\n",
+    "    common use case:\n",
+    "    cur_layer_img_w = conv2d_size_out(cur_layer_img_w, kernel_size, stride)\n",
+    "    cur_layer_img_h = conv2d_size_out(cur_layer_img_h, kernel_size, stride)\n",
+    "    to understand the shape for dense layer's input\n",
+    "    \"\"\"\n",
+    "    return (size - (kernel_size - 1) - 1) // stride  + 1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DQNAgent(nn.Module):\n",
+    "    def __init__(self, state_shape, n_actions, epsilon=0):\n",
+    "\n",
+    "        super().__init__()\n",
+    "        self.epsilon = epsilon\n",
+    "        self.n_actions = n_actions\n",
+    "        self.state_shape = state_shape\n",
+    "\n",
+    "        # Define your network body here. Please make sure agent is fully contained here\n",
+    "        # nn.Flatten() can be useful\n",
+    "        <YOUR CODE>\n",
+    "        \n",
+    "\n",
+    "    def forward(self, state_t):\n",
+    "        \"\"\"\n",
+    "        takes agent's observation (tensor), returns qvalues (tensor)\n",
+    "        :param state_t: a batch of 4-frame buffers, shape = [batch_size, 4, h, w]\n",
+    "        \"\"\"\n",
+    "        # Use your network to compute qvalues for given state\n",
+    "        qvalues = <YOUR CODE>\n",
+    "\n",
+    "        assert qvalues.requires_grad, \"qvalues must be a torch tensor with grad\"\n",
+    "        assert len(\n",
+    "            qvalues.shape) == 2 and qvalues.shape[0] == state_t.shape[0] and qvalues.shape[1] == n_actions\n",
+    "\n",
+    "        return qvalues\n",
+    "\n",
+    "    def get_qvalues(self, states):\n",
+    "        \"\"\"\n",
+    "        like forward, but works on numpy arrays, not tensors\n",
+    "        \"\"\"\n",
+    "        model_device = next(self.parameters()).device\n",
+    "        states = torch.tensor(states, device=model_device, dtype=torch.float)\n",
+    "        qvalues = self.forward(states)\n",
+    "        return qvalues.data.cpu().numpy()\n",
+    "\n",
+    "    def sample_actions(self, qvalues):\n",
+    "        \"\"\"pick actions given qvalues. Uses epsilon-greedy exploration strategy. \"\"\"\n",
+    "        epsilon = self.epsilon\n",
+    "        batch_size, n_actions = qvalues.shape\n",
+    "\n",
+    "        random_actions = np.random.choice(n_actions, size=batch_size)\n",
+    "        best_actions = qvalues.argmax(axis=-1)\n",
+    "\n",
+    "        should_explore = np.random.choice(\n",
+    "            [0, 1], batch_size, p=[1-epsilon, epsilon])\n",
+    "        return np.where(should_explore, random_actions, best_actions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = DQNAgent(state_shape, n_actions, epsilon=0.5).to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's try out our agent to see if it raises any errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(env, agent, n_games=1, greedy=False, t_max=10000):\n",
+    "    \"\"\" Plays n_games full games. If greedy, picks actions as argmax(qvalues). Returns mean reward. \"\"\"\n",
+    "    rewards = []\n",
+    "    for _ in range(n_games):\n",
+    "        s = env.reset()\n",
+    "        reward = 0\n",
+    "        for _ in range(t_max):\n",
+    "            qvalues = agent.get_qvalues([s])\n",
+    "            action = qvalues.argmax(axis=-1)[0] if greedy else agent.sample_actions(qvalues)[0]\n",
+    "            s, r, done, _ = env.step(action)\n",
+    "            reward += r\n",
+    "            if done:\n",
+    "                break\n",
+    "\n",
+    "        rewards.append(reward)\n",
+    "    return np.mean(rewards)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluate(env, agent, n_games=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Experience replay\n",
+    "For this assignment, we provide you with experience replay buffer. If you implemented experience replay buffer in last week's assignment, you can copy-paste it here **to get 2 bonus points**.\n",
+    "\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/exp_replay.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The interface is fairly simple:\n",
+    "* `exp_replay.add(obs, act, rw, next_obs, done)` - saves (s,a,r,s',done) tuple into the buffer\n",
+    "* `exp_replay.sample(batch_size)` - returns observations, actions, rewards, next_observations and is_done for `batch_size` random samples.\n",
+    "* `len(exp_replay)` - returns number of elements stored in replay buffer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from replay_buffer import ReplayBuffer\n",
+    "exp_replay = ReplayBuffer(10)\n",
+    "\n",
+    "for _ in range(30):\n",
+    "    exp_replay.add(env.reset(), env.action_space.sample(),\n",
+    "                   1.0, env.reset(), done=False)\n",
+    "\n",
+    "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "    5)\n",
+    "\n",
+    "assert len(exp_replay) == 10, \"experience replay size should be 10 because that's what maximum capacity is\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def play_and_record(initial_state, agent, env, exp_replay, n_steps=1):\n",
+    "    \"\"\"\n",
+    "    Play the game for exactly n steps, record every (s,a,r,s', done) to replay buffer. \n",
+    "    Whenever game ends, add record with done=True and reset the game.\n",
+    "    It is guaranteed that env has done=False when passed to this function.\n",
+    "\n",
+    "    PLEASE DO NOT RESET ENV UNLESS IT IS \"DONE\"\n",
+    "\n",
+    "    :returns: return sum of rewards over time and the state in which the env stays\n",
+    "    \"\"\"\n",
+    "    s = initial_state\n",
+    "    sum_rewards = 0\n",
+    "\n",
+    "    # Play the game for n_steps as per instructions above\n",
+    "    <YOUR CODE >\n",
+    "\n",
+    "    return sum_rewards, s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing your code.\n",
+    "exp_replay = ReplayBuffer(2000)\n",
+    "\n",
+    "state = env.reset()\n",
+    "play_and_record(state, agent, env, exp_replay, n_steps=1000)\n",
+    "\n",
+    "# if you're using your own experience replay buffer, some of those tests may need correction.\n",
+    "# just make sure you know what your code does\n",
+    "assert len(exp_replay) == 1000, \"play_and_record should have added exactly 1000 steps, \"\\\n",
+    "                                 \"but instead added %i\" % len(exp_replay)\n",
+    "is_dones = list(zip(*exp_replay._storage))[-1]\n",
+    "\n",
+    "assert 0 < np.mean(is_dones) < 0.1, \"Please make sure you restart the game whenever it is 'done' and record the is_done correctly into the buffer.\"\\\n",
+    "                                    \"Got %f is_done rate over %i steps. [If you think it's your tough luck, just re-run the test]\" % (\n",
+    "                                        np.mean(is_dones), len(exp_replay))\n",
+    "\n",
+    "for _ in range(100):\n",
+    "    obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "        10)\n",
+    "    assert obs_batch.shape == next_obs_batch.shape == (10,) + state_shape\n",
+    "    assert act_batch.shape == (\n",
+    "        10,), \"actions batch should have shape (10,) but is instead %s\" % str(act_batch.shape)\n",
+    "    assert reward_batch.shape == (\n",
+    "        10,), \"rewards batch should have shape (10,) but is instead %s\" % str(reward_batch.shape)\n",
+    "    assert is_done_batch.shape == (\n",
+    "        10,), \"is_done batch should have shape (10,) but is instead %s\" % str(is_done_batch.shape)\n",
+    "    assert [int(i) in (0, 1)\n",
+    "            for i in is_dones], \"is_done should be strictly True or False\"\n",
+    "    assert [\n",
+    "        0 <= a < n_actions for a in act_batch], \"actions should be within [0, n_actions)\"\n",
+    "\n",
+    "print(\"Well done!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Target networks\n",
+    "\n",
+    "We also employ the so called \"target network\" - a copy of neural network weights to be used for reference Q-values:\n",
+    "\n",
+    "The network itself is an exact copy of agent network, but it's parameters are not trained. Instead, they are moved here from agent's actual network every so often.\n",
+    "\n",
+    "$$ Q_{reference}(s,a) = r + \\gamma \\cdot \\max _{a'} Q_{target}(s',a') $$\n",
+    "\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/target_net.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_network = DQNAgent(agent.state_shape, agent.n_actions, epsilon=0.5).to(device)\n",
+    "# This is how you can load weights from agent into target network\n",
+    "target_network.load_state_dict(agent.state_dict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Learning with... Q-learning\n",
+    "Here we write a function similar to `agent.update` from tabular q-learning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute Q-learning TD error:\n",
+    "\n",
+    "$$ L = { 1 \\over N} \\sum_i [ Q_{\\theta}(s,a) - Q_{reference}(s,a) ] ^2 $$\n",
+    "\n",
+    "With Q-reference defined as\n",
+    "\n",
+    "$$ Q_{reference}(s,a) = r(s,a) + \\gamma \\cdot max_{a'} Q_{target}(s', a') $$\n",
+    "\n",
+    "Where\n",
+    "* $Q_{target}(s',a')$ denotes q-value of next state and next action predicted by __target_network__\n",
+    "* $s, a, r, s'$ are current state, action, reward and next state respectively\n",
+    "* $\\gamma$ is a discount factor defined two cells above.\n",
+    "\n",
+    "\n",
+    "__Note 1:__ there's an example input below. Feel free to experiment with it before you write the function.\n",
+    "\n",
+    "__Note 2:__ compute_td_loss is a source of 99% of bugs in this homework. If reward doesn't improve, it often helps to go through it line by line [with a rubber duck](https://rubberduckdebugging.com/).\n",
+    "\n",
+    "**Double DQN (+2 pts)**\n",
+    "\n",
+    "$$ Q_{reference}(s,a) = r(s, a) + \\gamma \\cdot\n",
+    "Q_{target}(s',argmax_{a'}Q_\\theta(s', a')) $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_td_loss(states, actions, rewards, next_states, is_done,\n",
+    "                    agent, target_network,\n",
+    "                    gamma=0.99,\n",
+    "                    check_shapes=False,\n",
+    "                    device=device):\n",
+    "    \"\"\" Compute td loss using torch operations only. Use the formulae above. \"\"\"\n",
+    "    states = torch.tensor(states, device=device, dtype=torch.float)    # shape: [batch_size, *state_shape]\n",
+    "\n",
+    "    # for some torch reason should not make actions a tensor\n",
+    "    actions = torch.tensor(actions, device=device, dtype=torch.long)    # shape: [batch_size]\n",
+    "    rewards = torch.tensor(rewards, device=device, dtype=torch.float)  # shape: [batch_size]\n",
+    "    # shape: [batch_size, *state_shape]\n",
+    "    next_states = torch.tensor(next_states, device=device, dtype=torch.float)\n",
+    "    is_done = torch.tensor(\n",
+    "        is_done.astype('float32'),\n",
+    "        device=device,\n",
+    "        dtype=torch.float\n",
+    "    )  # shape: [batch_size]\n",
+    "    is_not_done = 1 - is_done\n",
+    "\n",
+    "    # get q-values for all actions in current states\n",
+    "    predicted_qvalues = agent(states)\n",
+    "\n",
+    "    # compute q-values for all actions in next states\n",
+    "    predicted_next_qvalues = target_network(next_states)\n",
+    "    \n",
+    "    # select q-values for chosen actions\n",
+    "    predicted_qvalues_for_actions = predicted_qvalues[range(\n",
+    "        len(actions)), actions]\n",
+    "\n",
+    "    # compute V*(next_states) using predicted next q-values\n",
+    "    next_state_values = <YOUR CODE>\n",
+    "\n",
+    "    assert next_state_values.dim(\n",
+    "    ) == 1 and next_state_values.shape[0] == states.shape[0], \"must predict one value per state\"\n",
+    "\n",
+    "    # compute \"target q-values\" for loss - it's what's inside square parentheses in the above formula.\n",
+    "    # at the last state use the simplified formula: Q(s,a) = r(s,a) since s' doesn't exist\n",
+    "    # you can multiply next state values by is_not_done to achieve this.\n",
+    "    target_qvalues_for_actions = <YOUR CODE>\n",
+    "\n",
+    "    # mean squared error loss to minimize\n",
+    "    loss = torch.mean((predicted_qvalues_for_actions -\n",
+    "                       target_qvalues_for_actions.detach()) ** 2)\n",
+    "\n",
+    "    if check_shapes:\n",
+    "        assert predicted_next_qvalues.data.dim(\n",
+    "        ) == 2, \"make sure you predicted q-values for all actions in next state\"\n",
+    "        assert next_state_values.data.dim(\n",
+    "        ) == 1, \"make sure you computed V(s') as maximum over just the actions axis and not all axes\"\n",
+    "        assert target_qvalues_for_actions.data.dim(\n",
+    "        ) == 1, \"there's something wrong with target q-values, they must be a vector\"\n",
+    "\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sanity checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch = exp_replay.sample(\n",
+    "    10)\n",
+    "\n",
+    "loss = compute_td_loss(obs_batch, act_batch, reward_batch, next_obs_batch, is_done_batch,\n",
+    "                       agent, target_network,\n",
+    "                       gamma=0.99, check_shapes=True)\n",
+    "loss.backward()\n",
+    "\n",
+    "assert loss.requires_grad and tuple(loss.data.size()) == (\n",
+    "    ), \"you must return scalar loss - mean over batch\"\n",
+    "assert np.any(next(agent.parameters()).grad.data.cpu().numpy() !=\n",
+    "              0), \"loss must be differentiable w.r.t. network weights\"\n",
+    "assert np.all(next(target_network.parameters()).grad is None), \"target network should not have grads\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Main loop (3 pts)\n",
+    "\n",
+    "**If deadline is tonight and it has not converged:** It is ok. Send the notebook today and when it converges send it again.\n",
+    "If the code is exactly the same points will not be discounted.\n",
+    "\n",
+    "It's time to put everything together and see if it learns anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import trange\n",
+    "from IPython.display import clear_output\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seed = <your favourite random seed>\n",
+    "random.seed(seed)\n",
+    "np.random.seed(seed)\n",
+    "torch.manual_seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = make_env(seed)\n",
+    "state_shape = env.observation_space.shape\n",
+    "n_actions = env.action_space.n\n",
+    "state = env.reset()\n",
+    "\n",
+    "agent = DQNAgent(state_shape, n_actions, epsilon=1).to(device)\n",
+    "target_network = DQNAgent(state_shape, n_actions).to(device)\n",
+    "target_network.load_state_dict(agent.state_dict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Buffer of size $10^4$ fits into 5 Gb RAM.\n",
+    "\n",
+    "Larger sizes ($10^5$ and $10^6$ are common) can be used. It can improve the learning, but $10^4$ is quiet enough. $10^2$ will probably fail learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp_replay = ReplayBuffer(10**4)\n",
+    "for i in range(100):\n",
+    "    if not utils.is_enough_ram(min_available_gb=0.1):\n",
+    "        print(\"\"\"\n",
+    "            Less than 100 Mb RAM available. \n",
+    "            Make sure the buffer size in not too huge.\n",
+    "            Also check, maybe other processes consume RAM heavily.\n",
+    "            \"\"\"\n",
+    "             )\n",
+    "        break\n",
+    "    play_and_record(state, agent, env, exp_replay, n_steps=10**2)\n",
+    "    if len(exp_replay) == 10**4:\n",
+    "        break\n",
+    "print(len(exp_replay))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timesteps_per_epoch = 1\n",
+    "batch_size = 16\n",
+    "total_steps = 3 * 10**6\n",
+    "decay_steps = 10**6\n",
+    "\n",
+    "opt = torch.optim.Adam(agent.parameters(), lr=1e-4)\n",
+    "\n",
+    "init_epsilon = 1\n",
+    "final_epsilon = 0.1\n",
+    "\n",
+    "loss_freq = 50\n",
+    "refresh_target_network_freq = 5000\n",
+    "eval_freq = 5000\n",
+    "\n",
+    "max_grad_norm = 50\n",
+    "\n",
+    "n_lives = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_rw_history = []\n",
+    "td_loss_history = []\n",
+    "grad_norm_history = []\n",
+    "initial_state_v_history = []\n",
+    "step = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = env.reset()\n",
+    "for step in trange(step, total_steps + 1):\n",
+    "    if not utils.is_enough_ram():\n",
+    "        print('less that 100 Mb RAM available, freezing')\n",
+    "        print('make sure everythin is ok and make KeyboardInterrupt to continue')\n",
+    "        try:\n",
+    "            while True:\n",
+    "                pass\n",
+    "        except KeyboardInterrupt:\n",
+    "            pass\n",
+    "\n",
+    "    agent.epsilon = utils.linear_decay(init_epsilon, final_epsilon, step, decay_steps)\n",
+    "\n",
+    "    # play\n",
+    "    _, state = play_and_record(state, agent, env, exp_replay, timesteps_per_epoch)\n",
+    "\n",
+    "    # train\n",
+    "    < sample batch_size of data from experience replay >\n",
+    "\n",
+    "    loss = < compute TD loss >\n",
+    "\n",
+    "    loss.backward()\n",
+    "    grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), max_grad_norm)\n",
+    "    opt.step()\n",
+    "    opt.zero_grad()\n",
+    "\n",
+    "    if step % loss_freq == 0:\n",
+    "        td_loss_history.append(loss.data.cpu().item())\n",
+    "        grad_norm_history.append(grad_norm)\n",
+    "\n",
+    "    if step % refresh_target_network_freq == 0:\n",
+    "        # Load agent weights into target_network\n",
+    "        <YOUR CODE >\n",
+    "\n",
+    "    if step % eval_freq == 0:\n",
+    "        mean_rw_history.append(evaluate(\n",
+    "            make_env(clip_rewards=True, seed=step), agent, n_games=3 * n_lives, greedy=True)\n",
+    "        )\n",
+    "        initial_state_q_values = agent.get_qvalues(\n",
+    "            [make_env(seed=step).reset()]\n",
+    "        )\n",
+    "        initial_state_v_history.append(np.max(initial_state_q_values))\n",
+    "\n",
+    "        clear_output(True)\n",
+    "        print(\"buffer size = %i, epsilon = %.5f\" %\n",
+    "              (len(exp_replay), agent.epsilon))\n",
+    "\n",
+    "        plt.figure(figsize=[16, 9])\n",
+    "\n",
+    "        plt.subplot(2, 2, 1)\n",
+    "        plt.title(\"Mean reward per life\")\n",
+    "        plt.plot(mean_rw_history)\n",
+    "        plt.grid()\n",
+    "\n",
+    "        assert not np.isnan(td_loss_history[-1])\n",
+    "        plt.subplot(2, 2, 2)\n",
+    "        plt.title(\"TD loss history (smoothened)\")\n",
+    "        plt.plot(utils.smoothen(td_loss_history))\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.subplot(2, 2, 3)\n",
+    "        plt.title(\"Initial state V\")\n",
+    "        plt.plot(initial_state_v_history)\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.subplot(2, 2, 4)\n",
+    "        plt.title(\"Grad norm history (smoothened)\")\n",
+    "        plt.plot(utils.smoothen(grad_norm_history))\n",
+    "        plt.grid()\n",
+    "\n",
+    "        plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Agent is evaluated for 1 life, not for a whole episode of 5 lives. Rewards in evaluation are also truncated. Cuz this is what environment the agent is learning in and in this way mean rewards per life can be compared with initial state value\n",
+    "\n",
+    "**The goal is to get 15 points in the real env**. So 3 or better 4 points in the preprocessed one will probably be enough. You can interrupt learning then."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Final scoring is done on a whole episode with all 5 lives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_score = evaluate(\n",
+    "  make_env(clip_rewards=False, seed=9),\n",
+    "    agent, n_games=30, greedy=True, t_max=10 * 1000\n",
+    ") * n_lives\n",
+    "print('final score:', final_score)\n",
+    "assert final_score >= 15, 'not as cool as DQN can'\n",
+    "print('Cool!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to interpret plots:\n",
+    "\n",
+    "This aint no supervised learning so don't expect anything to improve monotonously. \n",
+    "* **TD loss** is the MSE between agent's current Q-values and target Q-values. It may slowly increase or decrease, it's ok. The \"not ok\" behavior includes going NaN or stayng at exactly zero before agent has perfect performance.\n",
+    "* **grad norm** just shows the intensivity of training. Not ok is growing to values of about 100 (or maybe even 50) though it depends on network architecture.\n",
+    "* **mean reward** is the expected sum of r(s,a) agent gets over the full game session. It will oscillate, but on average it should get higher over time (after a few thousand iterations...). \n",
+    " * In basic q-learning implementation it takes about 40k steps to \"warm up\" agent before it starts to get better.\n",
+    "* **Initial state V** is the expected discounted reward for episode in the oppinion of the agent. It should behave more smoothly than **mean reward**. It should get higher over time but sometimes can experience drawdowns because of the agaent's overestimates.\n",
+    "* **buffer size** - this one is simple. It should go up and cap at max size.\n",
+    "* **epsilon** - agent's willingness to explore. If you see that agent's already at 0.01 epsilon before it's average reward is above 0 - it means you need to increase epsilon. Set it back to some 0.2 - 0.5 and decrease the pace at which it goes down.\n",
+    "* Smoothing of plots is done with a gaussian kernel\n",
+    "\n",
+    "At first your agent will lose quickly. Then it will learn to suck less and at least hit the ball a few times before it loses. Finally it will learn to actually score points.\n",
+    "\n",
+    "**Training will take time.** A lot of it actually. Probably you will not see any improvment during first **150k** time steps (note that by default in this notebook agent is evaluated every 5000 time steps).\n",
+    "\n",
+    "But hey, long training time isn't _that_ bad:\n",
+    "![img](https://github.com/yandexdataschool/Practical_RL/raw/master/yet_another_week/_resource/training.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## About hyperparameters:\n",
+    "\n",
+    "The task has something in common with supervised learning: loss is optimized through the buffer (instead of Train dataset). But the distribution of states and actions in the buffer **is not stationary** and depends on the policy that generated it. It can even happen that the mean TD error across the buffer is very low but the performance is extremely poor (imagine the agent collecting data to the buffer always manages to avoid the ball).\n",
+    "\n",
+    "* Total timesteps and training time: It seems to be so huge, but actually it is normal for RL.\n",
+    "\n",
+    "* $\\epsilon$ decay shedule was taken from the original paper and is like traditional for epsilon-greedy policies. At the beginning of the training the agent's greedy policy is poor so many random actions should be taken.\n",
+    "\n",
+    "* Optimizer: In the original paper RMSProp was used (they did not have Adam in 2013) and it can work not worse than Adam. For us Adam was default and it worked.\n",
+    "\n",
+    "* lr: $10^{-3}$ would probably be too huge\n",
+    "\n",
+    "* batch size: This one can be very important: if it is too small the agent can fail to learn. Huge batch takes more time to process. If batch of size 8 can not be processed on the hardware you use take 2 (or even 4) batches of size 4, divide the loss on them by 2 (or 4) and make optimization step after both backward() calls in torch.\n",
+    "\n",
+    "* target network update frequency: has something in common with learning rate. Too frequent updates can lead to divergence. Too rare can lead to slow leraning. For millions of total timesteps thousands of inner steps seem ok. One iteration of target network updating is an iteration of the (this time approximate) $\\gamma$-compression that stands behind Q-learning. The more inner steps it makes the more accurate is the compression.\n",
+    "* max_grad_norm - just huge enough. In torch clip_grad_norm also evaluates the norm before clipping and it can be convenient for logging."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Video"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# record sessions\n",
+    "import gym.wrappers\n",
+    "env_monitor = gym.wrappers.Monitor(make_env(), directory=\"videos\", force=True)\n",
+    "sessions = [evaluate(env_monitor, agent, n_games=n_lives, greedy=True) for _ in range(10)]\n",
+    "env_monitor.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show video\n",
+    "from IPython.display import HTML\n",
+    "import os\n",
+    "\n",
+    "video_names = list(\n",
+    "    filter(lambda s: s.endswith(\".mp4\"), os.listdir(\"./videos/\")))\n",
+    "\n",
+    "HTML(\"\"\"\n",
+    "<video width=\"640\" height=\"480\" controls>\n",
+    "  <source src=\"{}\" type=\"video/mp4\">\n",
+    "</video>\n",
+    "\"\"\".format(\"./videos/\"+video_names[-1]))  # this may or may not be _last_ video. Try other indices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Let's have a closer look at this.\n",
+    "\n",
+    "If average episode score is below 200 using all 5 lives, then probably DQN has not converged fully. But anyway let's make a more complete record of an episode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_env = make_env(clip_rewards=False)\n",
+    "record = utils.play_and_log_episode(eval_env, agent)\n",
+    "print('total reward for life:', np.sum(record['rewards']))\n",
+    "for key in record:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(5, 5))\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "\n",
+    "ax.scatter(record['v_mc'], record['v_agent'])\n",
+    "ax.plot(sorted(record['v_mc']), sorted(record['v_mc']),\n",
+    "       'black', linestyle='--', label='x=y')\n",
+    "\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "ax.set_title('State Value Estimates')\n",
+    "ax.set_xlabel('Monte-Carlo')\n",
+    "ax.set_ylabel('Agent')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\\hat V_{Monte-Carlo}(s_t) = \\sum_{\\tau=0}^{episode~end} \\gamma^{\\tau-t}r_t$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Is there a big bias? It's ok, anyway it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bonus I (2 pts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**1.** Plot several (say 3) states with high and low spreads of Q estimate by actions i.e.\n",
+    "$$\\max_a \\hat Q(s,a) - \\min_a \\hat Q(s,a)\\$$\n",
+    "Please take those states from different episodes to make sure that the states are really different.\n",
+    "\n",
+    "What should high and low spread mean at least in the world of perfect Q-fucntions?\n",
+    "\n",
+    "Comment the states you like most.\n",
+    "\n",
+    "**2.** Plot several (say 3) states with high td-error and several states with high values of\n",
+    "$$| \\hat V_{Monte-Carlo}(s) - \\hat V_{agent}(s)|,$$ \n",
+    "$$\\hat V_{agent}(s)=\\max_a \\hat Q(s,a).$$ Please take those states from different episodes to make sure that the states are really different. From what part (i.e. beginning, middle, end) of an episode did these states come from?\n",
+    "\n",
+    "Comment the states you like most."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from utils import play_and_log_episode, img_by_obs\n",
+    "\n",
+    "<YOUR CODE>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bonus II (1-5 pts). Get High Score!\n",
+    "\n",
+    "1 point to you for each 50 points of your agent. Truncated by 5 points. Starting with 50 points, **not** 50 + threshold.\n",
+    "\n",
+    "One way is to train for several days and use heavier hardware (why not actually).\n",
+    "\n",
+    "Another way is to apply modifications (see **Bonus III**)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bonus III (2+ pts). Apply modifications to DQN.\n",
+    "\n",
+    "For inspiration see [Rainbow](https://arxiv.org/abs/1710.02298) - a version of q-learning that combines lots of them.\n",
+    "\n",
+    "Points for Bonus II and Bonus III fully stack. So if modified agent gets score 250+ you get 5 pts for Bonus II + points for modifications. If the final score is 40 then you get the points for modifications.\n",
+    "\n",
+    "\n",
+    "Some modifications:\n",
+    "* [Prioritized experience replay](https://arxiv.org/abs/1511.05952) (5 pts for your own implementation, 3 pts for using a ready one)\n",
+    "* [double q-learning](https://arxiv.org/abs/1509.06461) (2 pts)\n",
+    "* [dueling q-learning](https://arxiv.org/abs/1511.06581) (2 pts)\n",
+    "* multi-step heuristics (see [Rainbow](https://arxiv.org/abs/1710.02298)) (3 pts)\n",
+    "* [Noisy Nets](https://arxiv.org/abs/1706.10295) (3 pts)\n",
+    "* [distributional RL](https://arxiv.org/abs/1707.06887)(distributional and distributed stand for different things here) (5 pts)\n",
+    "* Other modifications (2+ pts depending on complexity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bonus IV (4+ pts). Distributed RL.\n",
+    "\n",
+    "Solve the task in a distributed way. It can strongly speed up learning. See [article](https://arxiv.org/pdf/1602.01783.pdf) or some guides."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**As usual bonus points for all the tasks fully stack.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/week04_approx_rl/seminar_pytorch.ipynb
+++ b/week04_approx_rl/seminar_pytorch.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "L8Ha-jdthEB0"
-   },
+   "metadata": {},
    "source": [
     "# Approximate q-learning\n",
     "\n",
@@ -15,15 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "iN__cWxZhEB4",
-    "outputId": "f67d01de-92fb-492b-b29c-b6d9c1c8a3bd"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# in google colab uncomment this\n",
@@ -46,11 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qG6oRIMmhEB_"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import gym\n",
@@ -63,15 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 303
-    },
-    "colab_type": "code",
-    "id": "I0myXAPjhECE",
-    "outputId": "3ce14874-d965-4168-87eb-5603426954cc"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "env = gym.make(\"CartPole-v0\").env\n",
@@ -85,10 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "r_5tjEZGhECK"
-   },
+   "metadata": {},
    "source": [
     "# Approximate Q-learning: building the network\n",
     "\n",
@@ -109,11 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "q0NoyjajhECM"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
@@ -124,11 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "uMtqOaDIhECS"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "network = nn.Sequential()\n",
@@ -143,11 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "turHm4gfhECd"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def get_action(state, epsilon=0):\n",
@@ -166,11 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "lCIZsXRUhECj"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "s = env.reset()\n",
@@ -197,10 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "sQbhj_lYhECo"
-   },
+   "metadata": {},
    "source": [
     "### Q-learning via gradient descent\n",
     "\n",
@@ -220,11 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qHVSnQ6QhECu"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def compute_td_loss(states, actions, rewards, next_states, is_done, gamma=0.99, check_shapes=False):\n",
@@ -277,11 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "p6iqsrTjhEC7"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# sanity checks\n",
@@ -298,10 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "uLkU3A7vhEDA"
-   },
+   "metadata": {},
    "source": [
     "### Playing the game"
    ]
@@ -309,11 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "PNJUql5HhEDB"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "opt = torch.optim.Adam(network.parameters(), lr=1e-4)\n",
@@ -323,11 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7_aGAweihEDG"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def generate_session(t_max=1000, epsilon=0, train=False):\n",
@@ -355,15 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 323
-    },
-    "colab_type": "code",
-    "id": "__bEbYEnhEDL",
-    "outputId": "e832418b-2a50-42b2-827e-f1f5908b76a1"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for i in range(1000):\n",
@@ -382,10 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vLSh6RxUhEDQ"
-   },
+   "metadata": {},
    "source": [
     "### How to interpret results\n",
     "\n",
@@ -400,10 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ShR9wTvehEDT"
-   },
+   "metadata": {},
    "source": [
     "### Record videos\n",
     "\n",
@@ -415,11 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "v2ZqyEE8hEDV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# record sessions\n",
@@ -433,11 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "wjznEV5JhEDa"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show video\n",
@@ -457,36 +371,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "NS3XimvohEDg"
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
-  "colab": {
-   "name": "seminar_pytorch.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week06_policy_based/reinforce_lasagne.ipynb
+++ b/week06_policy_based/reinforce_lasagne.ipynb
@@ -61,7 +61,7 @@
        "<matplotlib.image.AxesImage at 0x7f233bdd3fd0>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -499,7 +499,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/week07_[recap]_rnn/seminar_pytorch.ipynb
+++ b/week07_[recap]_rnn/seminar_pytorch.ipynb
@@ -1,16 +1,8 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
  "cells": [
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Generating names with recurrent neural networks\n",
     "\n",
@@ -22,8 +14,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -31,13 +25,11 @@
     "\n",
     "# if you're in in colab, uncomment\n",
     "# !wget https://raw.githubusercontent.com/yandexdataschool/Practical_RL/99ae2a3dae648428edbfc41fd10ed688e5365161/week07_%5Brecap%5D_rnn/names -O names"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Our data\n",
     "The dataset contains ~8k earthling names from different cultures, all in latin transcript.\n",
@@ -46,8 +38,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "start_token = \" \"\n",
@@ -55,38 +49,36 @@
     "with open(\"names\") as f:\n",
     "    lines = f.read()[:-1].split('\\n')\n",
     "    lines = [start_token + line for line in lines]"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print ('n samples = ',len(lines))\n",
     "for x in lines[::1000]:\n",
     "    print (x)\n",
     "    \n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "MAX_LENGTH = max(map(len, lines))\n",
     "print(\"max length =\", MAX_LENGTH)\n",
     "\n",
     "plt.title('Sequence length distribution')\n",
     "plt.hist(list(map(len, lines)),bins=25);"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Text processing\n",
     "\n",
@@ -94,8 +86,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#all unique characters go here\n",
     "tokens = <all unique characters in the dataset>\n",
@@ -106,13 +100,11 @@
     "print ('num_tokens = ', num_tokens)\n",
     "\n",
     "assert 50 < num_tokens < 60, \"Names should contain within 50 and 60 unique tokens depending on encoding\""
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Convert characters to integers\n",
     "\n",
@@ -123,17 +115,19 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "token_to_id = <dictionary of symbol -> its identifier (index in tokens list)>"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "assert len(tokens) == len(token_to_id), \"dictionaries must have same size\"\n",
     "\n",
@@ -141,13 +135,13 @@
     "    assert token_to_id[tokens[i]] == i, \"token identifier must be it's position in tokens list\"\n",
     "\n",
     "print(\"Seems alright!\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def to_matrix(lines, max_len=None, pad=token_to_id[' '], dtype='int32', batch_first = True):\n",
     "    \"\"\"Casts a list of names into rnn-digestable matrix\"\"\"\n",
@@ -163,24 +157,22 @@
     "        lines_ix = np.transpose(lines_ix)\n",
     "\n",
     "    return lines_ix"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#Example: cast 4 random names to matrices, pad with zeros\n",
     "print('\\n'.join(lines[::2000]))\n",
     "print(to_matrix(lines[::2000]))"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Recurrent neural network\n",
     "\n",
@@ -193,8 +185,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import torch, torch.nn as nn\n",
     "import torch.nn.functional as F\n",
@@ -238,22 +232,20 @@
     "    def initial_state(self, batch_size):\n",
     "        \"\"\" return rnn state before it processes first input (aka h0) \"\"\"\n",
     "        return torch.zeros(batch_size, self.num_units)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "char_rnn = CharRNNCell()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### RNN loop\n",
     "\n",
@@ -261,8 +253,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def rnn_loop(char_rnn, batch_ix):\n",
     "    \"\"\"\n",
@@ -278,13 +272,13 @@
     "        logprobs.append(logp_next)\n",
     "        \n",
     "    return torch.stack(logprobs, dim=1)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "batch_ix = to_matrix(lines[:5])\n",
     "batch_ix = torch.tensor(batch_ix, dtype=torch.int64)\n",
@@ -293,13 +287,11 @@
     "\n",
     "assert torch.max(logp_seq).data.numpy() <= 0\n",
     "assert tuple(logp_seq.size()) ==  batch_ix.shape + (num_tokens,)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Likelihood and gradients\n",
     "\n",
@@ -309,8 +301,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "predictions_logp = logp_seq[:, :-1]\n",
     "actual_next_tokens = batch_ix[:, 1:]\n",
@@ -318,33 +312,31 @@
     "logp_next = torch.gather(predictions_logp, dim=2, index=actual_next_tokens[:,:,None])\n",
     "\n",
     "loss = -logp_next.mean()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "loss.backward()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for w in char_rnn.parameters():\n",
     "    assert w.grad is not None and torch.max(torch.abs(w.grad)).data.numpy() != 0, \\\n",
     "        \"Loss is not differentiable w.r.t. a weight with shape %s. Check forward method.\" % (w.size(),)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### The training loop\n",
     "\n",
@@ -354,8 +346,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from IPython.display import clear_output\n",
     "from random import sample\n",
@@ -363,13 +357,13 @@
     "char_rnn = CharRNNCell()\n",
     "opt = torch.optim.Adam(char_rnn.parameters())\n",
     "history = []"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "for i in range(1000):\n",
@@ -394,13 +388,11 @@
     "        plt.show()\n",
     "\n",
     "assert np.mean(history[:10]) > np.mean(history[-10:]), \"RNN didn't converge.\""
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### RNN: sampling\n",
     "Once we've trained our network a bit, let's get to actually generating stuff. \n",
@@ -408,8 +400,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def generate_sample(char_rnn, seed_phrase=' ', max_length=MAX_LENGTH, temperature=1.0):\n",
     "    '''\n",
@@ -439,33 +433,31 @@
     "        x_sequence = torch.cat([x_sequence, next_ix], dim=1)\n",
     "        \n",
     "    return ''.join([tokens[ix] for ix in x_sequence.data.numpy()[0]])"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for _ in range(10):\n",
     "    print(generate_sample(char_rnn))"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for _ in range(50):\n",
     "    print(generate_sample(char_rnn, seed_phrase=' Trump'))"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Try it out!\n",
     "You've just implemented a recurrent language model that can be tasked with generating any kind of sequence, so there's plenty of data you can try it on:\n",
@@ -490,8 +482,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### More seriously\n",
     "\n",
@@ -507,8 +499,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "class CharRNNLoop(nn.Module):\n",
     "    def __init__(self, num_tokens=num_tokens, emb_size=16, rnn_num_units=64):\n",
@@ -524,13 +518,13 @@
     "        return next_logp\n",
     "    \n",
     "model = CharRNNLoop()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# the model applies over the whole sequence\n",
     "batch_ix = to_matrix(sample(lines, 32), max_len=MAX_LENGTH)\n",
@@ -543,20 +537,20 @@
     "                  batch_ix[:, :-1].contiguous().view(-1))\n",
     "\n",
     "loss.backward()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Here's another example"
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import torch, torch.nn as nn\n",
     "import torch.nn.functional as F\n",
@@ -584,13 +578,13 @@
     "        return torch.zeros(batch_size, self.num_units), torch.zeros(batch_size, self.num_units)\n",
     "    \n",
     "char_lstm = CharLSTMCell()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# the model applies over the whole sequence\n",
     "batch_ix = to_matrix(sample(lines, 32), max_len=MAX_LENGTH)\n",
@@ -603,16 +597,22 @@
     "                  batch_ix[:, :-1].contiguous().view(-1))\n",
     "\n",
     "loss.backward()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "__Bonus quest: __ implement a model that uses 2 LSTM layers (the second lstm uses the first as input) and train it on your data."
    ]
   }
- ]
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/week07_seq2seq/bonus_pytorch.ipynb
+++ b/week07_seq2seq/bonus_pytorch.ipynb
@@ -164,22 +164,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/week08_pomdp/homework_common_part2.ipynb
+++ b/week08_pomdp/homework_common_part2.ipynb
@@ -316,7 +316,7 @@
        "<matplotlib.text.Text at 0x111ae6a90>"
       ]
      },
-     "execution_count": 65,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/week08_pomdp/practice_tensorflow.ipynb
+++ b/week08_pomdp/practice_tensorflow.ipynb
@@ -430,7 +430,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 37,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/week09_policy_II/seminar_TRPO_pytorch.ipynb
+++ b/week09_policy_II/seminar_TRPO_pytorch.ipynb
@@ -83,7 +83,7 @@
        "<matplotlib.image.AxesImage at 0x7f3c2dc56dd8>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/week09_policy_II/seminar_TRPO_theano.ipynb
+++ b/week09_policy_II/seminar_TRPO_theano.ipynb
@@ -72,7 +72,7 @@
        "<matplotlib.image.AxesImage at 0x7f83846e0240>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     },


### PR DESCRIPTION
There are two commits. The first one fixes the JSON for three notebooks from Week 4 and Week 7 Recap:

```
week04_approx_rl/homework_pytorch_debug.ipynb
week04_approx_rl/homework_pytorch_main.ipynb
week07_[recap]_rnn/seminar_pytorch.ipynb
```

They had very large diff when I attempted to fix Colab setup in #336.

The second commit cleans up metadata in all notebooks using my (now standard) script:

```python
#!/usr/bin/env python3

import argparse
import sys
import subprocess
from pathlib import Path

parser = argparse.ArgumentParser()
parser.add_argument('path', type=Path)
parser.add_argument('--clear-outputs', action='store_true', help='Clear outputs of all cells')
args = parser.parse_args()

jq_cmd = [
    '(.cells[] | select(has("execution_count")) | .execution_count) = null',
    '.metadata = {"language_info": {"name": "python", "pygments_lexer": "ipython3"}}',
    '.cells[].metadata = {}',
    '(.cells[] | select(has("outputs")) | .outputs[] | select(has("execution_count")) | .execution_count) = null',
]

if args.clear_outputs:
    jq_cmd.append(
        '(.cells[] | select(has("outputs")) | .outputs) = []'
    )

cmd = [
    'jq',
    '--indent', '1',
    ' | '.join(jq_cmd),
    str(args.path),
]

formatted = subprocess.check_output(cmd, encoding='utf8')

with args.path.open('w') as fp:
    fp.write(formatted)
```

The two commits can (and should) be reviewed separately.