### PR TITLE
Fix unrandomness in atari.py nature_dqn_env (all copies of envs were …

### DIFF
--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -339,6 +339,7 @@ def nature_dqn_env(env_id, nenvs=None, seed=None,
 
     env = gym.make(env_id)
     env.seed(seed)
+    np.random.seed(seed)
     if summaries:
         env = TFSummaries(env)
     env = EpisodicLife(env)


### PR DESCRIPTION
…initialized the same)