### PR TITLE
[Week 6] seminar pytorch: Add no_grad hint

### DIFF
--- a/week06_policy_based/reinforce_pytorch.ipynb
+++ b/week06_policy_based/reinforce_pytorch.ipynb
@@ -100,6 +100,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: output value of this function is not a torch tensor, it's a numpy array.\n",
+    "So, here gradient calculation is not needed.\n",
+    "<br>\n",
+    "Use [no_grad](https://pytorch.org/docs/stable/autograd.html#torch.autograd.no_grad)\n",
+    "to suppress gradient calculation.\n",
+    "<br>\n",
+    "Also, `.detach()` (or legacy `.data` property) can be used instead, but there is a difference:\n",
+    "<br>\n",
+    "With `.detach()` computational graph is built but then disconnected from a particular tensor,\n",
+    "so `.detach()` should be used if that graph is needed for backprop via some other (not detached) tensor;\n",
+    "<br>\n",
+    "In contrast, no graph is built by any operation in `no_grad()` context, thus it's preferable here."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
Almost none of students use no_grad in their homeworks (they use detach/data instead).