### PR TITLE
Revert Taxi-v3 to v2 because gym in Coursera is too old

### DIFF
--- a/week1_intro/crossentropy_method.ipynb
+++ b/week1_intro/crossentropy_method.ipynb
@@ -40,7 +40,7 @@
     "import gym\n",
     "import numpy as np\n",
     "\n",
-    "env = gym.make(\"Taxi-v3\")\n",
+    "env = gym.make(\"Taxi-v2\")\n",
     "env.reset()\n",
     "env.render()"
    ]

--- a/week3_model_free/experience_replay.ipynb
+++ b/week3_model_free/experience_replay.ipynb
@@ -194,7 +194,7 @@
    "outputs": [],
    "source": [
     "import gym\n",
-    "env = gym.make(\"Taxi-v3\")\n",
+    "env = gym.make(\"Taxi-v2\")\n",
     "n_actions = env.action_space.n"
    ]
   },

--- a/week3_model_free/qlearning.ipynb
+++ b/week3_model_free/qlearning.ipynb
@@ -182,7 +182,7 @@
    "outputs": [],
    "source": [
     "import gym\n",
-    "env = gym.make(\"Taxi-v3\")\n",
+    "env = gym.make(\"Taxi-v2\")\n",
     "\n",
     "n_actions = env.action_space.n"
    ]


### PR DESCRIPTION
`Taxi-v3` doesn't work with `gym==0.14.0`.