### PR TITLE
Week 07 get rid of randomness of Vocab.from_lines

### DIFF
--- a/week07_seq2seq/voc.py
+++ b/week07_seq2seq/voc.py
@@ -23,7 +23,7 @@ class Vocab:
     def from_lines(lines, bos="__BOS__", eos="__EOS__", sep=''):
         flat_lines = sep.join(list(lines))
         flat_lines = list(flat_lines.split(sep)) if sep else list(flat_lines)
-        tokens = list(set(sep.join(flat_lines)))
+        tokens = sorted(set(sep.join(flat_lines)))
         tokens = [t for t in tokens if t not in (bos, eos) and len(t) != 0]
         tokens = [bos, eos] + tokens
         return Vocab(tokens, bos, eos, sep)


### PR DESCRIPTION
From launch to launch the jupyter notebook, one can notice, that Vocab.token_to_ix differs. It is due to randomness in Vocab.from_lines, in which tokens are stored in set, and elements order in set is undefined.

The fix is to store tokens in list in sorted way.