### PR TITLE
Fix redundant .setup_complete check

### DIFF
--- a/week04_[recap]_deep_learning/seminar_tensorflow.ipynb
+++ b/week04_[recap]_deep_learning/seminar_tensorflow.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "if 'google.colab' in sys.modules and not os.path.exists('.setup_complete'):\n",
+    "if 'google.colab' in sys.modules:\n",
     "    %tensorflow_version 1.x\n",
     "    \n",
     "    if not os.path.exists('.setup_complete'):\n",

--- a/week04_approx_rl/homework_tf.ipynb
+++ b/week04_approx_rl/homework_tf.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "if 'google.colab' in sys.modules and not os.path.exists('.setup_complete'):\n",
+    "if 'google.colab' in sys.modules:\n",
     "    %tensorflow_version 1.x\n",
     "    \n",
     "    if not os.path.exists('.setup_complete'):\n",

--- a/week04_approx_rl/seminar_tf.ipynb
+++ b/week04_approx_rl/seminar_tf.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "if 'google.colab' in sys.modules and not os.path.exists('.setup_complete'):\n",
+    "if 'google.colab' in sys.modules:\n",
     "    %tensorflow_version 1.x\n",
     "    \n",
     "    if not os.path.exists('.setup_complete'):\n",

--- a/week06_policy_based/reinforce_tensorflow.ipynb
+++ b/week06_policy_based/reinforce_tensorflow.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "if 'google.colab' in sys.modules and not os.path.exists('.setup_complete'):\n",
+    "if 'google.colab' in sys.modules:\n",
     "    %tensorflow_version 1.x\n",
     "    \n",
     "    if not os.path.exists('.setup_complete'):\n",

--- a/week07_seq2seq/practice_tf.ipynb
+++ b/week07_seq2seq/practice_tf.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "if 'google.colab' in sys.modules and not os.path.exists('.setup_complete'):\n",
+    "if 'google.colab' in sys.modules:\n",
     "    %tensorflow_version 1.x\n",
     "    \n",
     "    if not os.path.exists('.setup_complete'):\n",


### PR DESCRIPTION
With the extra check, `%tensorflow_version 1.x` is not called on kernel restarts.