### PR TITLE
[Week7 seq2seq] Fix wrong description of attention in week7 in bonus_pytorch.ipynb

### DIFF
--- a/week07_seq2seq/bonus_pytorch.ipynb
+++ b/week07_seq2seq/bonus_pytorch.ipynb
@@ -96,8 +96,8 @@
     "#### step-by-step guide:\n",
     "\n",
     "- compute scores between $h_{e, j}^i$ and $h_{d}^i$ $\\forall j = 1, ... , \\text{len(enc_seq)}$, where i -- number of decoder step\n",
-    "- apply softmax to scores and get weights for each vector\n",
-    "- obtain attention vector using scores and weight matrix\n",
+    "- apply softmax to scores and get weight for each vector\n",
+    "- obtain attention vector using enc_seq and weights\n",
     "\n"
    ]
   },


### PR DESCRIPTION
Some context:

One of the students sent a homework with wrong logic in Attention:

He multiplies attention weights by their own logits (instead of multiplying encoder sequence by attention weights).

I said him about his error. But he said that such logic had beed described in the course notebook.

I have checked it and turns out that:

1. There was the original bonus.ipynb with correct description and class draft;

2. Then one of the students created bonus_pytorch.ipynb with wrong description and his PR was merged.

Now, as most of the students use pytorch, they can see wrong description and write wrong code.

Here we fix the description.