### PR TITLE
Upgrade atari_wrapper to tf2

### DIFF
--- a/week06_policy_based/a2c-optional.ipynb
+++ b/week06_policy_based/a2c-optional.ipynb
@@ -214,8 +214,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now is the time to implement the advantage actor critic algorithm itself. You can look into your lecture,\n",
-    "[Mnih et al. 2016](https://arxiv.org/abs/1602.01783) paper, and [lecture](https://www.youtube.com/watch?v=Tol_jw5hWnI&list=PLkFD6_40KJIxJMR-j5A1mkxK26gh_qg37&index=20) by Sergey Levine."
+    "# Actor-critic objective\n",
+    "\n",
+    "Here we define a loss function that uses rollout above to train advantage actor-critic agent.\n",
+    "\n",
+    "\n",
+    "Our loss consists of three components:\n",
+    "\n",
+    "* __The policy \"loss\"__\n",
+    " $$ \\hat J = {1 \\over T} \\cdot \\sum_t { \\log \\pi(a_t | s_t) } \\cdot A_{const}(s,a) $$\n",
+    "  * This function has no meaning in and of itself, but it was built such that\n",
+    "  * $ \\nabla \\hat J = {1 \\over N} \\cdot \\sum_t { \\nabla \\log \\pi(a_t | s_t) } \\cdot A(s,a) \\approx \\nabla E_{s, a \\sim \\pi} R(s,a) $\n",
+    "  * Therefore if we __maximize__ J_hat with gradient descent we will maximize expected reward\n",
+    "  \n",
+    "  \n",
+    "* __The value \"loss\"__\n",
+    "  $$ L_{td} = {1 \\over T} \\cdot \\sum_t { [r + \\gamma \\cdot V_{const}(s_{t+1}) - V(s_t)] ^ 2 }$$\n",
+    "  * Ye Olde TD_loss from q-learning and alike\n",
+    "  * If we minimize this loss, V(s) will converge to $V_\\pi(s) = E_{a \\sim \\pi(a | s)} R(s,a) $\n",
+    "\n",
+    "\n",
+    "* __Entropy Regularizer__\n",
+    "  $$ H = - {1 \\over T} \\sum_t \\sum_a {\\pi(a|s_t) \\cdot \\log \\pi (a|s_t)}$$\n",
+    "  * If we __maximize__ entropy we discourage agent from predicting zero probability to actions\n",
+    "  prematurely (a.k.a. exploration)\n",
+    "  \n",
+    "  \n",
+    "So we optimize a linear combination of $L_{td}$ $- \\hat J$, $-H$\n",
+    "  \n",
+    "```\n",
+    "\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "\n",
+    "\n",
+    "__One more thing:__ since we train on T-step rollouts, we can use N-step formula for advantage for free:\n",
+    "  * At the last step, $A(s_t,a_t) = r(s_t, a_t) + \\gamma \\cdot V(s_{t+1}) - V(s) $\n",
+    "  * One step earlier, $A(s_t,a_t) = r(s_t, a_t) + \\gamma \\cdot r(s_{t+1}, a_{t+1}) + \\gamma ^ 2 \\cdot V(s_{t+2}) - V(s) $\n",
+    "  * Et cetera, et cetera. This way agent starts training much faster since it's estimate of A(s,a) depends less on his (imperfect) value function and more on actual rewards. There's also a [nice generalization](https://arxiv.org/abs/1506.02438) of this.\n",
+    "\n",
+    "\n",
+    "__Note:__ it's also a good idea to scale rollout_len up to learn longer sequences. You may wish set it to >=20 or to start at 10 and then scale up as time passes."
    ]
   },
   {
@@ -288,9 +334,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/week06_policy_based/a2c-optional.ipynb
+++ b/week06_policy_based/a2c-optional.ipynb
@@ -144,10 +144,10 @@
     "To train the part of the model that predicts state values you will need to compute the value targets. \n",
     "Any callable could be passed to `EnvRunner` to be applied to each partial trajectory after it is collected. \n",
     "Thus, we can implement and use `ComputeValueTargets` callable. \n",
-    "The formula for the value targets is simple:\n",
+    "The formula for the value targets is simple, it's the right side of the following equation:\n",
     "\n",
     "$$\n",
-    "\\hat v(s_t) = \\left( \\sum_{t'=0}^{T - 1 - t} \\gamma^{t'}r_{t+t'} \\right) + \\gamma^T \\hat{v}(s_{t+T}),\n",
+    "V(s_t) = \\left( \\sum_{t'=0}^{T - 1 - t} \\gamma^{t'} \\cdot r (s_{t+t'}, a_{t + t'}) \\right) + \\gamma^T \\cdot V(s_{t+T}),\n",
     "$$\n",
     "\n",
     "In implementation, however, do not forget to use \n",
@@ -165,7 +165,7 @@
     "class ComputeValueTargets:\n",
     "    def __init__(self, policy, gamma=0.99):\n",
     "        self.policy = policy\n",
-    "    \n",
+    "\n",
     "    def __call__(self, trajectory):\n",
     "        # This method should modify trajectory inplace by adding\n",
     "        # an item with key 'value_targets' to it.\n",
@@ -258,10 +258,7 @@
     "__One more thing:__ since we train on T-step rollouts, we can use N-step formula for advantage for free:\n",
     "  * At the last step, $A(s_t,a_t) = r(s_t, a_t) + \\gamma \\cdot V(s_{t+1}) - V(s) $\n",
     "  * One step earlier, $A(s_t,a_t) = r(s_t, a_t) + \\gamma \\cdot r(s_{t+1}, a_{t+1}) + \\gamma ^ 2 \\cdot V(s_{t+2}) - V(s) $\n",
-    "  * Et cetera, et cetera. This way agent starts training much faster since it's estimate of A(s,a) depends less on his (imperfect) value function and more on actual rewards. There's also a [nice generalization](https://arxiv.org/abs/1506.02438) of this.\n",
-    "\n",
-    "\n",
-    "__Note:__ it's also a good idea to scale rollout_len up to learn longer sequences. You may wish set it to >=20 or to start at 10 and then scale up as time passes."
+    "  * Et cetera, et cetera. This way agent starts training much faster since it's estimate of A(s,a) depends less on his (imperfect) value function and more on actual rewards. There's also a [nice generalization](https://arxiv.org/abs/1506.02438) of this."
    ]
   },
   {

--- a/week06_policy_based/a2c-optional.ipynb
+++ b/week06_policy_based/a2c-optional.ipynb
@@ -265,6 +265,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also look into your lecture,\n",
+    "[Mnih et al. 2016](https://arxiv.org/abs/1602.01783) paper, and [lecture](https://www.youtube.com/watch?v=Tol_jw5hWnI&list=PLkFD6_40KJIxJMR-j5A1mkxK26gh_qg37&index=20) by Sergey Levine."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -213,12 +213,12 @@ class SummariesBase(gym.Wrapper):
         self.episode_counter = 0
         self.prefix = prefix or self.env.spec.id
 
-        nenvs = getattr(self.env.unwrapped, "nenvs", 1)
-        self.rewards = np.zeros(nenvs)
-        self.had_ended_episodes = np.zeros(nenvs, dtype=np.bool)
-        self.episode_lengths = np.zeros(nenvs)
+        self.nenvs = getattr(self.env.unwrapped, "nenvs", 1)
+        self.rewards = np.zeros(self.nenvs)
+        self.had_ended_episodes = np.zeros(self.nenvs, dtype=np.bool)
+        self.episode_lengths = np.zeros(self.nenvs)
         self.reward_queues = [deque([], maxlen=running_mean_size)
-                              for _ in range(nenvs)]
+                              for _ in range(self.nenvs)]
         self.global_step = 0
 
     def should_write_summaries(self):
@@ -261,8 +261,9 @@ class SummariesBase(gym.Wrapper):
             self.reward_queues[i].append(self.rewards[i])
             self.rewards[i] = 0
 
+        self.global_step += self.nenvs
+
         if self.should_write_summaries():
-            self.global_step += 1
             self.add_summaries()
         return obs, rew, done, info
 
@@ -274,27 +275,22 @@ class SummariesBase(gym.Wrapper):
 
 
 class TFSummaries(SummariesBase):
-    """ Writes env summaries using TensorFlow."""
+    """ Writes env summaries using TensorFlow.
+        In order to write summaries in a specific directory,
+        you may define a writer and set it as default just before
+        training loop as in an example here
+        https://www.tensorflow.org/api_docs/python/tf/summary
+        Other summaries could be added in A2C class or elsewhere
+    """
 
-    def __init__(self, env, log_dir, prefix=None,
+    def __init__(self, env, prefix=None,
                  running_mean_size=100, step_var=None):
 
         super().__init__(env, prefix, running_mean_size)
 
-        if log_dir:
-            self.log_dir = log_dir
-        else:
-            raise ValueError(f"you should specify log_dir if "
-                             f"you want to store tf summaries, "
-                             f"now log_dir is {log_dir}")
-
-        import tensorflow as tf
-        self.summary_writer = tf.summary.create_file_writer(log_dir)
-
     def add_summary_scalar(self, name, value):
         import tensorflow as tf
-        with self.summary_writer.as_default():
-            tf.summary.scalar(name, value, self.global_step)
+        tf.summary.scalar(name, value, self.global_step)
 
 
 class NumpySummaries(SummariesBase):
@@ -321,8 +317,8 @@ class NumpySummaries(SummariesBase):
         self._summaries[name].append((self._summary_step, value))
 
 
-def nature_dqn_env(env_id, nenvs=None, seed=None, summaries='TensorFlow',
-                   log_dir=None, clip_reward=True):
+def nature_dqn_env(env_id, nenvs=None, seed=None,
+                   summaries='TensorFlow', clip_reward=True):
     """ Wraps env as in Nature DQN paper. """
     if "NoFrameskip" not in env_id:
         raise ValueError(f"env_id must have 'NoFrameskip' but is {env_id}")
@@ -344,7 +340,7 @@ def nature_dqn_env(env_id, nenvs=None, seed=None, summaries='TensorFlow',
         if summaries == 'Numpy':
             env = NumpySummaries(env, prefix=env_id)
         elif summaries == 'TensorFlow':
-            env = TFSummaries(env, prefix=env_id, log_dir=log_dir)
+            env = TFSummaries(env, prefix=env_id)
         elif summaries:
             raise ValueError(f"summaries must be either Numpy, "
                              f"or TensorFlow, or a falsy value, but is {summaries}")
@@ -357,7 +353,7 @@ def nature_dqn_env(env_id, nenvs=None, seed=None, summaries='TensorFlow',
     if summaries == 'Numpy':
         env = NumpySummaries(env)
     elif summaries == 'TensorFlow':
-        env = TFSummaries(env, log_dir=log_dir)
+        env = TFSummaries(env)
     elif summaries:
         raise ValueError(f"summaries must be either Numpy, "
                          f"or TensorFlow, or a falsy value, but is {summaries}")

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -283,7 +283,7 @@ class TFSummaries(SummariesBase):
                          else tf.summary.experimental.get_step())
 
     def add_summary_scalar(self, name, value):
-        tf.summary.scalar(name, value, step = self.step_var)
+        tf.summary.scalar(name, value, step=self.step_var)
 
 
 class NumpySummaries(SummariesBase):
@@ -303,7 +303,7 @@ class NumpySummaries(SummariesBase):
     def clear(cls):
         cls._summaries = defaultdict(list)
 
-    def __init__(self, env, prefix = None, running_mean_size = 100):
+    def __init__(self, env, prefix=None, running_mean_size=100):
         super().__init__(env, prefix, running_mean_size)
 
     def add_summary_scalar(self, name, value):
@@ -315,6 +315,9 @@ def nature_dqn_env(env_id, nenvs=None, seed=None,
     """ Wraps env as in Nature DQN paper. """
     if "NoFrameskip" not in env_id:
         raise ValueError(f"env_id must have 'NoFrameskip' but is {env_id}")
+
+    if summaries:
+        summaries_class = NumpySummaries if summaries == 'Numpy' else TFSummaries
     if nenvs is not None:
         if seed is None:
             seed = list(range(nenvs))
@@ -330,7 +333,6 @@ def nature_dqn_env(env_id, nenvs=None, seed=None,
             for i, env_seed in enumerate(seed)
         ])
         if summaries:
-            summaries_class = NumpySummaries if summaries == 'Numpy' else TFSummaries
             env = summaries_class(env, prefix=env_id)
         if clip_reward:
             env = ClipReward(env)
@@ -339,7 +341,7 @@ def nature_dqn_env(env_id, nenvs=None, seed=None,
     env = gym.make(env_id)
     env.seed(seed)
     if summaries:
-        env = TFSummaries(env)
+        env = summaries_class(env, prefix=env_id)
     env = EpisodicLife(env)
     if "FIRE" in env.unwrapped.get_action_meanings():
         env = FireReset(env)

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -337,16 +337,17 @@ def nature_dqn_env(env_id, nenvs=None, seed=None,
 
         env = ParallelEnvBatch([
             lambda i=i, env_seed=env_seed: nature_dqn_env(
-                env_id, seed=env_seed, summaries=False, clip_reward=False)
+                env_id, seed=env_seed, summaries=None, clip_reward=False)
             for i, env_seed in enumerate(seed)
         ])
-        if summaries == 'Numpy':
-            env = NumpySummaries(env, prefix=env_id)
-        elif summaries == 'TensorFlow':
-            env = TFSummaries(env, prefix=env_id)
-        elif summaries:
-            raise ValueError(f"summaries must be either Numpy, "
-                             f"or TensorFlow, or a falsy value, but is {summaries}")
+        if summaries is not None:
+            if summaries == 'Numpy':
+                env = NumpySummaries(env, prefix=env_id)
+            elif summaries == 'TensorFlow':
+                env = TFSummaries(env, prefix=env_id)
+            else:
+                raise ValueError(
+                    f"Unknown `summaries` value: expected either 'Numpy' or 'TensorFlow', got {summaries}")
         if clip_reward:
             env = ClipReward(env)
         return env

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -280,11 +280,10 @@ class TFSummaries(SummariesBase):
 
         import tensorflow as tf
         self.step_var = (step_var if step_var is not None
-                         else tf.train.get_global_step())
+                         else tf.summary.experimental.get_step())
 
     def add_summary_scalar(self, name, value):
-        import tensorflow as tf
-        tf.contrib.summary.scalar(name, value, step = self.step_var)
+        tf.summary.scalar(name, value, step = self.step_var)
 
 
 class NumpySummaries(SummariesBase):

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -283,6 +283,7 @@ class TFSummaries(SummariesBase):
                          else tf.summary.experimental.get_step())
 
     def add_summary_scalar(self, name, value):
+        import tensorflow as tf
         tf.summary.scalar(name, value, step=self.step_var)
 
 

--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -221,6 +221,9 @@ class SummariesBase(gym.Wrapper):
                               for _ in range(self.nenvs)]
         self.global_step = 0
 
+    def add_summary_scalar(self, name, value):
+        raise NotImplementedError
+
     def should_write_summaries(self):
         """ Returns true if it's time to write summaries. """
         return np.all(self.had_ended_episodes)


### PR DESCRIPTION
1) There were 2 functions in the class TFSummary, they used tf1 API, I replaced them with corresponding functions from tf2 API (both are referenced here https://www.tensorflow.org/api_docs/python/tf/summary/scalar).
2) There was unnecessary import in the add_summary_scalar function. Tensorflow has to be imported by the time this method is called cause importing is in the constructor of the TFSummary class.
3) There was no alternative in natrure_dqn to use NumPy summary even if a corresponding argument is set into a corresponding state -- bug fix.
4) Different style of putting (or not putting) spaces between an argument name and its value in a function call in one file -- code style fix