### PR TITLE
Revert part of https://github.com/yandexdataschool/Practical_RL/pull/448

### DIFF
--- a/week04_approx_rl/seminar_tf.ipynb
+++ b/week04_approx_rl/seminar_tf.ipynb
@@ -123,7 +123,7 @@
     "    recap: with p = epsilon pick random action, else pick action with highest Q(s,a)\n",
     "    \"\"\"\n",
     "    \n",
-    "    q_values = network(state[None])[0]\n",
+    "    q_values = network.predict(state[None])[0]\n",
     "    \n",
     "    <YOUR CODE>\n",
     "\n",

--- a/week04_approx_rl/seminar_tf.ipynb
+++ b/week04_approx_rl/seminar_tf.ipynb
@@ -105,6 +105,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert not tf.test.is_gpu_available(), \\\n",
+    "    \"Please complete this assignment without a GPU. If you use a GPU, the code \" \\\n",
+    "    \"will run a lot slower due to a lot of copying to and from GPU memory. \" \\\n",
+    "    \"To disable the GPU in Colab, go to Runtime → Change runtime type → None.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "network = keras.models.Sequential()\n",
     "network.add(L.InputLayer(state_dim))\n",
     "\n",


### PR DESCRIPTION
https://www.coursera.org/learn/practical-rl/discussions/all/threads/RRaAuhCbEeuoKgpcLmLqdw

I guess that either TF or Keras broke backwards compatibility, and `__call__()` no longer accepts Numpy tensors, contrary to what is said in https://stackoverflow.com/a/60871692.

We introduced this here: https://github.com/yandexdataschool/Practical_RL/pull/448/files#diff-61c5d5737d7f6d9831dd0d962e3e4feee9bc47dd25924cd56b16d8c499e3a43dR126