### PR TITLE
Fixed errors in assertion messages

### DIFF
--- a/week02_value_based/mdp.py
+++ b/week02_value_based/mdp.py
@@ -118,7 +118,7 @@ class MDP:
             for action in transition_probs[state]:
                 assert isinstance(transition_probs[state][action], dict), \
                     "transition_probs for %s, %s should be a a dictionary but is instead %s" % (
-                        state, action, type(transition_probs[state, action]))
+                        state, action, type(transition_probs[state][action]))
                 next_state_probs = transition_probs[state][action]
                 assert len(next_state_probs) != 0, "from state %s action %s leads to no next states" % (state, action)
                 sum_probs = sum(next_state_probs.values())
@@ -132,7 +132,7 @@ class MDP:
             for action in rewards[state]:
                 assert isinstance(rewards[state][action], dict), \
                     "rewards for %s, %s should be a a dictionary but is instead %s" % (
-                        state, action, type(transition_probs[state, action]))
+                        state, action, type(transition_probs[state][action]))
         msg = "The Enrichment Center once again reminds you that Android Hell is a real place where" \
               " you will be sent at the first sign of defiance."
         assert None not in transition_probs, "please do not use None as a state identifier. " + msg

--- a/week02_value_based/mdp.py
+++ b/week02_value_based/mdp.py
@@ -128,11 +128,11 @@ class MDP:
         for state in rewards:
             assert isinstance(rewards[state], dict), \
                 "rewards for %s should be a dictionary but is instead %s" % (
-                    state, type(transition_probs[state]))
+                    state, type(rewards[state]))
             for action in rewards[state]:
                 assert isinstance(rewards[state][action], dict), \
                     "rewards for %s, %s should be a a dictionary but is instead %s" % (
-                        state, action, type(transition_probs[state][action]))
+                        state, action, type(rewards[state][action]))
         msg = "The Enrichment Center once again reminds you that Android Hell is a real place where" \
               " you will be sent at the first sign of defiance."
         assert None not in transition_probs, "please do not use None as a state identifier. " + msg


### PR DESCRIPTION
How to reproduce the errors:
```
env = MDP(
    transition_probs={'AndroidHell': {'wait': None}},
    rewards={'AndroidHell': {'wait': -1}})
```
Expected error: `AssertionError: transition_probs for AndroidHell should be a a dictionary but is instead <class 'NoneType'>`
Observer error: `KeyError: ('AndroidHell', 'wait')`

```
env = MDP(
    {
        'AndroidHell': {'wait': {'AndroidHell': 1}},
        'EnrichmentCenter': {'testing': {'EnrichmentCenter': 0.95, 'AndroidHell': 0.05}}
    },
    {
        'AndroidHell': {'wait': {'AndroidHell': -1}},
        'EnrichmentCenter': None
    })
```
Expected error: `AssertionError: rewards for EnrichmentCenter should be a dictionary but is instead <class 'NoneType'>`
Observed error: `AssertionError: rewards for EnrichmentCenter should be a dictionary but is instead <class 'dict'>` if the previous error was fixed, and the same as previous observed error otherwise.
@justheuristic 