### PR TITLE
Fix numpy beta distribution arguments

### DIFF
--- a/week05_explore/week5.ipynb
+++ b/week05_explore/week5.ipynb
@@ -1585,7 +1585,7 @@
     "def sample_normal_gamma(mu, lmbd, alpha, beta):\n",
     "    \"\"\" https://en.wikipedia.org/wiki/Normal-gamma_distribution\n",
     "    \"\"\"\n",
-    "    tau = np.random.gamma(alpha, beta)\n",
+    "    tau = np.random.gamma(shape=alpha, scale=1 / beta)\n",
     "    mu = np.random.normal(mu, 1.0 / np.sqrt(lmbd * tau))\n",
     "    return mu, tau\n",
     "\n",


### PR DESCRIPTION
В [numpy иная параметризация](https://numpy.org/doc/stable/reference/random/generated/numpy.random.gamma.html) бета-распределения - не `alpha, beta` (`shape, rate`), а `k, theta` (`shape, scale`), на [википедии](https://en.wikipedia.org/wiki/Gamma_distribution) можно увидеть обе. [Связь](https://en.wikipedia.org/wiki/Gamma_distribution#Characterization_using_shape_%CE%B1_and_rate_%CE%B2) между ними - `scale = 1 / rate`.

Хотя это почти не влияет на то, как обучается модель в задании.