### PR TITLE
Week04 suggestion

### DIFF
--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -115,22 +115,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "##############################################################################\n",
-    "### If you run into a problem \"Exception: ROM is missing for breakout ...\" ###\n",
-    "### in the next cell, plese uncomment the following lines:                 ###\n",
-    "##############################################################################\n",
-    "# ! wget http://www.atarimania.com/roms/Roms.rar\n",
-    "# ! mkdir ROM/\n",
-    "# ! unrar e Roms.rar ROM/\n",
-    "# ! python -m atari_py.import_roms ROM/ > /dev/null"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -887,7 +887,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm import trange\n",
     "REPLAY_BUFFER_SIZE = 10**4\n",
     "N_STEPS = 100\n",
     "\n",

--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -903,11 +903,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from tqdm import trange\n",
     "REPLAY_BUFFER_SIZE = 10**4\n",
     "N_STEPS = 100\n",
     "\n",
     "exp_replay = ReplayBuffer(REPLAY_BUFFER_SIZE)\n",
-    "for i in range(REPLAY_BUFFER_SIZE // N_STEPS):\n",
+    "for i in trange(REPLAY_BUFFER_SIZE // N_STEPS):\n",
     "    if not utils.is_enough_ram(min_available_gb=0.1):\n",
     "        print(\"\"\"\n",
     "            Less than 100 Mb RAM available. \n",

--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -1061,9 +1061,9 @@
     "final_score = evaluate(\n",
     "  make_env(clip_rewards=False, seed=9),\n",
     "    agent, n_games=30, greedy=True, t_max=10 * 1000\n",
-    ") * n_lives\n",
+    ")\n",
     "print('final score:', final_score)\n",
-    "assert final_score >= 15, 'not as cool as DQN can'\n",
+    "assert final_score >= 3, 'not as cool as DQN can'\n",
     "print('Cool!')"
    ]
   },

--- a/week04_approx_rl/homework_pytorch_main.ipynb
+++ b/week04_approx_rl/homework_pytorch_main.ipynb
@@ -115,6 +115,22 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "##############################################################################\n",
+    "### If you run into a problem \"Exception: ROM is missing for breakout ...\" ###\n",
+    "### in the next cell, plese uncomment the following lines:                 ###\n",
+    "##############################################################################\n",
+    "# ! wget http://www.atarimania.com/roms/Roms.rar\n",
+    "# ! mkdir ROM/\n",
+    "# ! unrar e Roms.rar ROM/\n",
+    "# ! python -m atari_py.import_roms ROM/ > /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
Hey! I just thought this change might be helpful! Just for a better understanding of what time I can stop my long learning and be on the same scale as the graph and `final_score` variable. 

Because right now, for some reason, we're doing the following:
```python3
final_score = evaluate(
  make_env(clip_rewards=False, seed=9),
    agent, n_games=30, greedy=True, t_max=10 * 1000
) * 5
assert final_score >= 15, "not as cool as DQN can"
```
Suggestion:
```python3
final_score = evaluate(
  make_env(clip_rewards=False, seed=9),
    agent, n_games=30, greedy=True, t_max=10 * 1000
)
assert final_score >= 3, "not as cool as DQN can"
```
What do you think?

Also, I faced with this [problem](https://github.com/openai/atari-py/issues/83), and added [this](https://github.com/openai/atari-py/issues/83#issuecomment-864356148) solution, I tested it on collab and my laptop, so I can say It worked and helped me.