### PR TITLE
Support MacOS in A2C homework multiprocessing

### DIFF
--- a/week06_policy_based/atari_wrappers.py
+++ b/week06_policy_based/atari_wrappers.py
@@ -1,6 +1,9 @@
 """ Environment wrappers. """
 from collections import defaultdict, deque
 
+import multiprocessing
+multiprocessing.set_start_method("fork")
+
 import cv2
 import gym
 import gym.spaces as spaces


### PR DESCRIPTION
Multiprocessing in Python works differently on Windows and on Linux. On Windows it copies the objects and in Linux it doesn't. As a result, some code that works fine on Linux may not work on Windows. E.g. in our A2C homework we use lambda functions.
Lambda functions are not serializable, so object copying during multiprocessing would fail on Windows. As for MacOS, it can behave like Linux or like Windows depending on settings.

In this commit I added an instruction that will make the multiprocessing behave like Linux