### PR TITLE
fix: fix np float for current numpy version

### DIFF
--- a/week01_intro/crossentropy_method.ipynb
+++ b/week01_intro/crossentropy_method.ipynb
@@ -147,7 +147,7 @@
     "s, a, r = generate_session(env, policy)\n",
     "assert type(s) == type(a) == list\n",
     "assert len(s) == len(a)\n",
-    "assert type(r) in [float, np.float]"
+    "assert type(r) in [float, np.float64]"
    ]
   },
   {


### PR DESCRIPTION
np.float is deprecated in a current version of numpy
The next best guess is that this variable will be of type np.float64