### PR TITLE
Fix n-step EV-SARSA reward indexing

### DIFF
--- a/week03_model_free/homework.ipynb
+++ b/week03_model_free/homework.ipynb
@@ -1617,7 +1617,7 @@
     "\n",
     "        tau = self.t - self.n_steps\n",
     "        if tau >= 0:\n",
-    "            start_index, end_index = tau + 1, min(tau + self.n_steps, self.T)\n",
+    "            start_index, end_index = tau, min(tau + self.n_steps, self.T)\n",
     "            G = 0\n",
     "            # <YOUR CODE HERE>\n",
     "            G =\n",


### PR DESCRIPTION
Correct n-step return computation in NStepEVSarsaAgent by starting reward accumulation from the proper memory index, which fixes nstep_evsarsa_1 getting stuck at -10000.