### PR TITLE
week07: fix off-by-one error in encoder state indexing

### DIFF
--- a/week07_seq2seq/basic_model_torch.py
+++ b/week07_seq2seq/basic_model_torch.py
@@ -31,7 +31,7 @@ class BasicTranslationModel(nn.Module):
         enc_seq, _ = self.enc0(inp_emb)
 
         # select last element w.r.t. mask
-        end_index = infer_length(inp, self.inp_voc.eos_ix)
+        end_index = infer_length(inp, self.inp_voc.eos_ix, include_eos=False)
         end_index[end_index >= inp.shape[1]] = inp.shape[1] - 1
         enc_last = enc_seq[range(0, enc_seq.shape[0]), end_index.detach(), :]
 


### PR DESCRIPTION
`infer_length()` with `include_eos=True` (default) returns the length of the sequence, including the EOS token. Treating length as index, we are fetching the embedding for the first token after EOS.

With `include_eos=False`, we are getting the length of the sequence without EOS, which, when treated as index, fetches the embedding for EOS.

https://github.com/yandexdataschool/Practical_RL/blob/b626bddd97dacfaf5f1e3132fb7ea941fb492c7d/week07_seq2seq/basic_model_theano.py#L50 (previous Theano version) uses `only_return_final=True`, which returns the final hidden state automatically.

The very first version of this file (https://github.com/yandexdataschool/Practical_RL/blob/66b93dee91b6bd4ece386d6d7ac16393d89b09b2/week07_seq2seq/basic_model_torch.py#L34-L35) already has this issue.

Fixes https://github.com/yandexdataschool/Practical_RL/issues/551.